### PR TITLE
Update 404.md

### DIFF
--- a/_pages/404.md
+++ b/_pages/404.md
@@ -1,6 +1,5 @@
 ---
 title: "Page Not Found"
-excerpt: "Page not found. Your pixels are in another canvas."
 sitemap: false
 permalink: /404.html
 ---


### PR DESCRIPTION
There's a bug in Jekyll version 3.9.4 (recently released), something to do with the Excerpt tag in the frontmatter/metadata of pages in the _pages directory. This PR removes the `Excerpt` tag from all pages in the _pages directory.

Bug details: https://github.com/jekyll/jekyll/issues/9544

Workaround: https://github.com/academicpages/academicpages.github.io/issues/1878

Error in the build file:
/usr/local/bundle/gems/jekyll-3.9.4/lib/jekyll/excerpt.rb:135:in `extract_excerpt': undefined method `excerpt_separator' for #<Jekyll::Page @name="404.md"> (NoMethodError)