### PR TITLE
Tag chapter 78 as co-written-with-claude

### DIFF
--- a/_posts/2026-05-04-chapter-78.md
+++ b/_posts/2026-05-04-chapter-78.md
@@ -7,6 +7,7 @@ modified: 2026-05-04
 categories:
   - campaign
 tags:
+  - co-written-with-claude
   - eve-of-ruin
   - fight
   - guest-player


### PR DESCRIPTION
Chapter 78 was the first Claude-drafted chapter, but it never got the `co-written-with-claude` tag — so the [tag archive](https://todhilton.com/dnd/tags/) shows the run starting at chapter 79 when it actually starts at 78.

Its own trailing comment documents this:

> This chapter was drafted by Claude. I had Claude review the 77 chapters I had written to understand the storylines, characters, and my writing style. I dictated my notes into a Google Doc, pasted that into Claude, and had it write a first draft, then a second. I manually edited the final draft, putting my own touches and style on it.

One line added, placed alphabetically to match chapters 79–83.

**Note:** I left `modified:` at `2026-05-04` rather than bumping it. This is a metadata correction, not a revision to the chapter's content, and bumping it would show readers a misleading "updated" date. Easy to change if you'd rather it reflect the edit.