### PR TITLE
Add Claude project docs from a full read of all 83 chapters

### DIFF
--- a/.claude/story-so-far.md
+++ b/.claude/story-so-far.md
@@ -4,9 +4,13 @@ Storylines and character arcs, for use when drafting or revising. The appendix
 (`_posts/2023-01-23-appendix.md`) is the reference index — who, what, where. This is the shape of
 the story: what each arc was about, what changed for each character, and what was left open.
 
-**Coverage: chapters 1–39**, read in full. Chapters 40–83 are not yet written up here at this
-depth. The threads below are traced as far as ch. 39; where one is known to continue later it says
-so, but the later arcs deserve their own pass.
+**Coverage: chapters 1–39**, read in full, cross-checked against the appendix. Chapters 40–83 are
+not yet written up here at this depth. The threads below are traced as far as ch. 39; where one is
+known to continue later it says so, but the later arcs deserve their own pass.
+
+Note that **chapters 53–55 do not exist as posts** — they were sessions that never got written up.
+The appendix records their content (the arrival in Neverwinter, the Gilded Glyph, Hallix Mausoleum,
+meeting Alustriel Silverhand), and ch. 56 opens as if the reader had been there.
 
 ---
 
@@ -18,10 +22,14 @@ Four strangers walking the Ha-derech west toward Elsemar, each for their own rea
 in ch. 2, then **Chimera's Bane** from ch. 7 on, after Dolor renames them coming out of a dream.
 
 They save a halfling shopkeeper, **Ben Dabbler**, from bandits and follow him home to Wayside. Ben
-farms **Hero's Wort**, a stimulant crop, and a **chimera** has been burning his fields. The elf
-**Cindel** — scorched armor, billowing cape, a shaft of sunlight that finds her and only her on an
+farms **Hero's Wort**, a stimulant crop, and a **chimera** has been burning his fields. **Cindel
+Trueshot** — scorched armor, billowing cape, a shaft of sunlight that finds her and only her on an
 overcast day, "Huzzah!" — sells them the job and a recipe for Chimera's Bane, which she later
 admits is "a traditional preparation for battling chimeras, but it's also total bullshit."
+(Chapters 1–4 call Cindel an elf; the appendix calls her half-elven. Unresolved.)
+
+The road they're on is **the Ha-derech**, and the appendix preserves the joke: *ha-derech* already
+means "the road," so everyone calling it "the Ha-derech" is saying "the the road."
 
 The job goes sideways: Cindel and her band, **the Low Elves**, are caught stealing Ben's crop
 because Hero's Wort makes her faster and sharper and she needs to be better. The party fights them,
@@ -60,6 +68,11 @@ No announcement, no summary. The roster turns over inside one chapter, entirely 
 Gven's search for her brother **Torp**, who left their tribe eight years ago for his *Coming Out*
 and was seen in Elsemar looking unhappy, in a building topped by a statue of a merchant standing on
 an orc.
+
+The appendix supplies the detail that makes this an arc rather than an errand: **Gven is on her own
+*Coming Out* journey while searching for him.** Both siblings walked out of the same tribe on the
+same rite of passage. Torp came back a zealot. Whatever Gven becomes is the other answer to the
+same question, and the campaign has been running that comparison since ch. 5 without stating it.
 
 Elsemar is where the campaign's politics live. Since **The Conflict** (also called The Uprising),
 magic and religion are legal but watched: the **Hands of the Wand** monitor arcane users, the **Eyes
@@ -155,6 +168,13 @@ in ch. 34 and 37, and only Gven can understand the words.
 the exact amount owed and nothing more. "Justice wears many faces." Gleaming Blade is looted off a
 goblin as a rusty sword in ch. 7 and turns out to be a paladin's. His running gag — the agile rogue
 who is the only one who ever falls — starts in ch. 36 and pays off across 37 and 38.
+
+He is called a rogue but doesn't fight like one class: by ch. 38 he's using Action Surge and Second
+Wind (fighter) alongside Uncanny Dodge (rogue), and later chapters give him Green-Flame Blade and
+Toll the Dead. The appendix explains the last of it — **his warlock powers come from a deal with
+Fenseck**, an efreeti/djinni, who first appears disguised as **Dave Chevits**, the halfling with the
+knitting needles locked under the ziggurat in ch. 47. Dolor's patron was in the room, in costume,
+before the reader knew there was a patron.
 
 **Grindlefoot** — quiet competence, played straight. Wild shapes into whatever the moment needs and
 gets stuck in his own webbing at least twice. Comic cover story: whenever he has to vanish, the

--- a/.claude/story-so-far.md
+++ b/.claude/story-so-far.md
@@ -1,0 +1,188 @@
+# Story so far
+
+Storylines and character arcs, for use when drafting or revising. The appendix
+(`_posts/2023-01-23-appendix.md`) is the reference index — who, what, where. This is the shape of
+the story: what each arc was about, what changed for each character, and what was left open.
+
+**Coverage: chapters 1–39**, read in full. Chapters 40–83 are not yet written up here at this
+depth. The threads below are traced as far as ch. 39; where one is known to continue later it says
+so, but the later arcs deserve their own pass.
+
+---
+
+## Arc I — Wayside (ch. 1–13)
+
+Four strangers walking the Ha-derech west toward Elsemar, each for their own reasons: **Dolor**
+(tiefling rogue), **Gven** (half-orc barbarian), **Grindlefoot** (halfling druid), and **Xantic**
+(gnome artificer). They call themselves **the Mixed Nuts** after Gven blurts it out under pressure
+in ch. 2, then **Chimera's Bane** from ch. 7 on, after Dolor renames them coming out of a dream.
+
+They save a halfling shopkeeper, **Ben Dabbler**, from bandits and follow him home to Wayside. Ben
+farms **Hero's Wort**, a stimulant crop, and a **chimera** has been burning his fields. The elf
+**Cindel** — scorched armor, billowing cape, a shaft of sunlight that finds her and only her on an
+overcast day, "Huzzah!" — sells them the job and a recipe for Chimera's Bane, which she later
+admits is "a traditional preparation for battling chimeras, but it's also total bullshit."
+
+The job goes sideways: Cindel and her band, **the Low Elves**, are caught stealing Ben's crop
+because Hero's Wort makes her faster and sharper and she needs to be better. The party fights them,
+Ben heals Cindel mid-brawl and screams at everyone to stop, and then the chimera arrives and makes
+the argument moot. Gven takes the dragon's head off and says "huzzah."
+
+The second half of the arc is the town's, not the party's. **Preva** the florist lost her husband
+and daughter months ago. A child's doll in the road leads to goblin caves, a ranger named **Lyra
+Swiftarrow**, and a goblin cult worshipping **the Great Mouth** — a hill giant. They free **Elar**,
+who survived by being funny, and his daughter **Vera**, whom the giant kept as a wind-up toy and
+who survived by pretending to be one.
+
+That rescue causes the **Battle of Wayside** (ch. 12–13). The goblins come back in waves chanting
+*filgit* — "find it" — because the giant wants its toy returned. The town is defended by four
+adventurers, a band of thieves, and a ranger in a tree. Gven ends it: still under the giant's magical
+fear, enraged that a creature would weaponize something her tribe holds sacred, she runs up Dolor's
+offered knee and takes the giant's head off shouting "NOOO FEEAAARR!"
+
+> Fear is a tool to be used in battle… Fear is not something that is forced upon you, it is a source
+> of power that comes from within yourself.
+
+That's the Sky Bison tribe's ethic, and it's the clearest statement of who Gven is in the whole run.
+
+## The changeover (ch. 14)
+
+The single most important structural fact in the early chapters. **Bilwin** and **Mond** walk into
+Wayside as strangers to each other and to everyone else, arriving just after the battle ends —
+Bilwin loudly, self-titled "the Magnificent," playing a hurdy-gurdy so badly that Trill offers him
+free drinks on condition he stop. In the same chapter **Xantic leaves for good**, staying behind to
+protect the town that took him in, and hands Trill a music box on his way out the door.
+
+No announcement, no summary. The roster turns over inside one chapter, entirely through scene.
+
+## Arc II — Elsemar (ch. 15–28)
+
+Gven's search for her brother **Torp**, who left their tribe eight years ago for his *Coming Out*
+and was seen in Elsemar looking unhappy, in a building topped by a statue of a merchant standing on
+an orc.
+
+Elsemar is where the campaign's politics live. Since **The Conflict** (also called The Uprising),
+magic and religion are legal but watched: the **Hands of the Wand** monitor arcane users, the **Eyes
+of the Star** monitor the faithful, and Mond has to register at the Hall of Records and wear a badge
+marking him as a magic user. Cast a spell alone and nobody minds. Cast five at once and you're a
+problem.
+
+Three strands braid together:
+
+1. **The city.** **Tella**, who runs the Broken Spy Glass, turns out to belong to the **Heart of the
+   People** — a secret group who watch the watchers. After the party wrecks his tavern in a fight,
+   he revives their victims (killing a Damian's thugs invites revenge), gets them cleared, and
+   recruits them. Their first job is the Food Alley business (ch. 19–21): animated donuts, enchanted
+   flour, and a Waffle Wizards manager sabotaging her competition. It's comic relief and it's also
+   how they earn Tella's trust.
+
+2. **The warehouse.** **Davanor** is a *Damian* — root *dam*, "blood," which is why his job center
+   asks for a few drops before hiring. His warehouse takes deliveries from **Erebore**, **Oreleone**,
+   and **Amonah** — and Amonah is on no current map. A crate holds **illegal holy symbols**, and the
+   ledgers show an initial **T** two weeks back.
+
+3. **The gods.** An old map from **Whichway** the cartographer and a lecture from **Professor
+   Verin** put together the shape of it: the gods emerged from a hole in the world, made homes among
+   the races, then closed the hole. The islands off the coast were the seat of their pantheons.
+
+Ch. 27 ends with the three strands meeting in the rain:
+
+> "Where the fuck have you been, Torp?"
+
+**Ch. 28 is the arc's payoff and the campaign's turn.** Torp is Davanor. He was shipwrecked, washed
+up on Amonah, and found faith. He blames every magic user for The Conflict and intends to exterminate
+them — starting with Elsemar, then all of Eritz. He loves his sister, tells her to tell their parents
+he's fine, punches her softly on the shoulder the way he did when they were young, and warns her
+that if she stays he'll deal with her and her friends "in a permanent manner."
+
+Gven doesn't fight him. She says she can't support him but will try to understand it — and then
+chooses the harder path: not killing Davanor, but sailing to Amonah to find out what made him.
+Kill him and the gods find another fanatic.
+
+## Arc III — The voyage and Amonah (ch. 29–39)
+
+At sea aboard the **Iron Vulture** with **Cap'n Don Karnahge**, who turns out to be an artificer:
+his ship becomes a faraday cage in ch. 28 and *flies* in ch. 32.
+
+The arc belongs to Bilwin and Gven.
+
+**Bilwin's faith returns.** A young kraken attacks in ch. 29, he prays for a blessing, and for the
+first time in decades **Hanseath answers** — not heard but felt, an old worn tunic suddenly become
+dragon scale mail. It shakes him badly. He spends chapters praying, unable to remember how he did
+it. In ch. 31 he asks Gven to beat him up, on the theory that Hanseath comes in moments of danger.
+In ch. 32 Hanseath simply shows up: an old dwarf with a huge tankard spilling beer into his beard.
+
+> "Dig deep enough, and the mountain's always there." … "Now, what the fuck are you doing?"
+
+What he tells them reframes the campaign. **The gods are a glitch** — not part of Olam's natural
+order. After The Conflict they were given an ultimatum: leave and keep some followers and some
+power, or keep fighting and lose everything. Some of them are unhappy with that deal and are
+working on a plan. That's what Torp got caught in.
+
+**Gven earns Tempest Edge.** **Veylara**, a 25-foot storm giant who keeps a sanctuary inside her own
+storms, walks Gven down the beach and asks why she's *really* on this journey. Gven's answer is her
+tribe: half-bloods and humans who survive by mutual support, elders who remember what The Conflict
+cost people who were neither magical nor religious. Veylara gives her the dagger from her boot —
+five and a half feet of storm giant steel, sister-forged to her own greatsword. **Gven gives back
+the Gruumsh medallion her father carved**, and promises to return the blade one day and trade back.
+
+Then Amonah: harpies, a pirate cove, jungle that "kinda wants to kill ya," a stone golem on a monkey
+bridge who says "You are not worthy," and **Valindra**, an elven wizard living on a floating rock,
+who has studied the island for decades and can't enter the temple herself. She tells them the volcano
+temple is not a representation of a god's home but the **source of a god's power — their soul** —
+and that deep inside is a **red gate** guarding the origin of the gods. Pilgrimages have increased.
+Her advice: "don't trust your senses overly much."
+
+The arc ends mid-approach, still short of the temple, fighting an undead tyrannosaurus that vomits
+zombies.
+
+---
+
+## Character threads
+
+**Gven** — the spine of chapters 1–39. Looking for her brother; finds him and finds him monstrous;
+chooses to understand rather than kill. Fear is a tool, not a weakness (ch. 13). Carries Tempest
+Edge on loan and owes both the blade and a reunion to Veylara. Her father's medallion hangs from a
+storm giant's ear.
+
+**Bilwin** — arrives as a punchline in ch. 14 and is treated as one for a while. The turn is early
+though: in ch. 15 he buries a dead wizard he never met, pours out his beer over the grave, and it's
+the first time the group sees him serious. Then Hanseath comes back and the joke acquires a floor.
+Running gag with real weight: he plays badly for thirty chapters, then plays beautifully in Dwarven
+in ch. 34 and 37, and only Gven can understand the words.
+
+**Dolor** — tinkerer's son, whose parents were pacifists cheated by wealthy clients, so he burgled
+the exact amount owed and nothing more. "Justice wears many faces." Gleaming Blade is looted off a
+goblin as a rusty sword in ch. 7 and turns out to be a paladin's. His running gag — the agile rogue
+who is the only one who ever falls — starts in ch. 36 and pays off across 37 and 38.
+
+**Grindlefoot** — quiet competence, played straight. Wild shapes into whatever the moment needs and
+gets stuck in his own webbing at least twice. Comic cover story: whenever he has to vanish, the
+others tell people he's gone to relieve himself, and it works for entire chapters. His ethic shows
+in ch. 38: he disturbs a bee hive by accident, apologizes to the bees in their own language, then
+seeds and grows a forest around their hive — "for generations after this day, the buzzing inhabitants
+of that hive speak reverently about the *Great One Who Spoke To Us*."
+
+**Mond** — arrives silent, answers "yep," and stays the most guarded of the five. Being a registered
+magic user in a city that watches magic users is his whole situation. He learns to sail and takes
+real pleasure in the Iron Vulture's mechanics. Signature: a pink lightning bolt.
+
+**Xantic** — ch. 1–14 only. Curiosity with no brakes: stabs his own foot to test a potion, blows up
+a child's doll before anyone can stop him, knocks himself out on a table and sleeps through the
+Battle of Wayside. Leaves to protect Wayside. Has his own character post.
+
+## Threads left open in ch. 1–39
+
+- **Tempest Edge is borrowed.** Gven owes Veylara the sword's return and holds nothing of her
+  family's in the meantime.
+- **Torp is alive** and still in Elsemar planning genocide. Gven's last words to him were that she'd
+  try to understand.
+- **The red gate** inside the volcano temple, and whatever the increased pilgrimages mean.
+- **Lyra's favor.** She drew a symbol in the dirt — a U with a tick through the top right — and said
+  to mark it anywhere and a ranger would come. Never used.
+- **The Heart of the People.** Tella's contact for reaching him is **Brooj**, the loxodon archivist at
+  Elsemar's Hall of Records.
+- **The crow** that adopted Bilwin after the wizard's burial and followed the party down the road.
+- **The tiny blue fae** who inspected the camp in ch. 35, admired Tempest Edge, nodded to Dolor, and
+  left without a word.
+- **Xantic and Trill** in Wayside. **Cindel and the Low Elves** still there too.

--- a/.claude/to-do-list.md
+++ b/.claude/to-do-list.md
@@ -1,0 +1,144 @@
+# To-do list
+
+Tracked suggestions from reading the full corpus (ch. 1–83) and the appendix. Nothing here has been
+acted on — these are proposals for Tod to accept, reject, or reorder. Check items off in place.
+
+Grouped by size, biggest commitment first.
+
+---
+
+## 1. Convert list-form combat to prose (19 chapters)
+
+The largest item. These chapters still render turn-by-turn bulleted combat with damage numbers on
+the page, under a visible `## Fight choreography` heading. The intent is that all combat is prose.
+
+- [ ] ch. 6
+- [ ] ch. 7
+- [ ] ch. 8
+- [ ] ch. 9
+- [ ] ch. 10 — heading reads `## Encounter choreography` (the Vera rescue, a stealth set piece)
+- [ ] ch. 12
+- [ ] **ch. 13 — biggest job.** Twelve numbered rounds of the Battle of Wayside, no prose at all
+- [ ] ch. 14
+- [ ] ch. 17
+- [ ] ch. 21
+- [ ] ch. 25
+- [ ] ch. 27
+- [ ] ch. 29
+- [ ] ch. 30 — heading reads `## Storm choreography`; a non-combat skill challenge, eight rounds
+- [ ] ch. 31
+- [ ] ch. 33
+- [ ] ch. 35
+- [ ] ch. 36
+- [ ] ch. 38 — partial; already has prose *and* the list. Just needs the comment cleanup
+- [ ] ch. 1 — combat is already prose; only the `## Fight choreography` heading needs removing
+
+**Model to follow:** ch. 38 carries both forms in one file. The comment says "Green grung 4 -
+Grapples Dolor and rubs his hands over Dolor's neck"; the prose says the creature "lands on Dolor's
+back, grabs hold tightly of his neck, and secretes a slimy substance onto his skin," and later
+Dolor wonders where a naked frog was keeping a knife. Keep the list in an HTML comment as the
+working record, write prose from it, drop the numbers.
+
+**Also worth doing while in there:** chapters 2, 3, 4, 39, and 43 have prose already but retain
+`<!-- Step-by-step -->` comment blocks. Those are fine to leave — they're working notes, and
+CLAUDE.md says to preserve HTML comments.
+
+---
+
+## 2. Chapters 53, 54, 55 were never written
+
+Not a numbering skip — three sessions that never got written up. The appendix documents their
+content and links to them, so **seven appendix links are 404s on the live site**, and ch. 56 opens
+with "The adventurers leave The Gilded Glyph," a shop the reader has never seen.
+
+What happened in them, per the appendix: the arrival in Neverwinter, the Gilded Glyph (magic shop,
+Maelis Varn), the Fucking Duck (dwarven jeweler), Hallix Mausoleum, and first contact with
+Alustriel Silverhand.
+
+- [ ] Decide: write them, or renumber, or leave them as a gap and fix the links to point elsewhere
+
+---
+
+## 3. Appendix corrections
+
+**Do not fix silently — these are content decisions.** Listed roughly by how much damage they'd do
+if a future chapter trusted them.
+
+### Factual
+
+- [ ] **Eyes of the Star and Hand of the Wand have their descriptions swapped.** Ch. 5 is explicit:
+      the Hands of the Wand track *magic users* and are magic users themselves; the Eyes of the Star
+      monitor *religious and faith-based* groups. The appendix says the reverse for both. The names
+      side with ch. 5 — wand, arcane. This is load-bearing worldbuilding.
+- [ ] **"Everwinter" should be "Evernight"** (2 places: the city entry and the Shadowfell entry).
+      Ch. 59, 60, and 63 all say Evernight, as does ch. 59's tag. Evernight is also the canonical
+      Forgotten Realms name for Neverwinter's Shadowfell mirror.
+- [ ] **The Davanor entry is stale.** Still reads "Unknown gender and species… person of interest in
+      Torp's disappearance," which ch. 28 resolved — Davanor *is* Torp. The two remain separate
+      entries in separate sections (Torp under Characters, Davanor under Foes). Merge, cross-
+      reference, or leave Davanor as a deliberate in-world stub.
+- [ ] **Cindel:** "half-elven" in the appendix, "elf" every time she appears in ch. 1–4. Pick one.
+
+### Open markers left in the file
+
+- [ ] Indrina Lamsensettle — `[UPDATE - ch. ??]`
+- [ ] Temple of Aish — `TODO - UPDATE Gustaf's map of the temple`
+
+### Typos and inconsistencies
+
+- [ ] "Cyndal" for Cindel, in the Low Elves membership list
+- [ ] "Inda Malayui" (Characters) vs "Inda Malayuri" (Ships) — same person
+- [ ] "The Guilded Glyph" → "Gilded" (in the Fucking Duck entry)
+- [ ] Elden Keyward described as "Male elven scholar" then "enlists the group to find **her**"
+      (copy-paste from the Sarcelle / Indrina / Umberto entries, which share the sentence)
+- [ ] "praticioners" → practitioners (Eyes of the Star entry)
+- [ ] "proprieter" → proprietor (Boscoe); "penchance" → penchant (Dave Chevits)
+
+### Structural
+
+- [ ] 15 entries carry no chapter citation while the rest do: Elar, Herbert, Lyra Swiftarrow, Preva,
+      Ro'qu-ell-a, Vera, Gruumsh, Preva's Flower Shop, Lamayum River, Eritz, Mirganor, Olam, Quiet
+      Valley, Unmarked Territories, Wayside
+- [ ] Dolindar Family is filed under **Characters** but is a family/group — belongs under Groups
+- [ ] Davanor, K'ren, Chuck, and Squiggy are filed under **Foes, monsters, & creatures** but are
+      people. Defensible for antagonists; inconsistent with Cabanna and Magnus being under Characters
+
+---
+
+## 4. Proofreading across chapters
+
+Roughly 48 recurring misspellings in ch. 60–77 alone, and the same pattern earlier.
+
+- [ ] **`halfing` for `halfling`** — 11 occurrences, and spellcheck won't flag it. Highest value fix
+- [ ] Others that recur: `concious`, `acquiesence`, `irridescent`, `death throws` (for "throes"),
+      `occured`, `catastrophy`, `posessions`, `accomodations`, `demeaner`, `respit`
+- [ ] **Nyx's surname is spelled two ways.** Ch. 39's prose says "Whisperfang" (4×); its own guest
+      credit and ch. 41–42 say "Whiskerfang." Whiskerfang is the one that stuck
+- [ ] A general spellcheck pass before publishing is the single cheapest quality improvement
+      available anywhere in this list
+
+---
+
+## 5. Tags and metadata
+
+- [ ] **Ch. 78 is missing `co-written-with-claude`.** It was the first Claude-drafted chapter — its
+      own trailing comment says so — but only 79–83 carry the tag. Its current tags are
+      `eve-of-ruin`, `fight`, `guest-player`, `landro`, `mournland`
+
+---
+
+## 6. Craft notes (optional, not defects)
+
+Observations from the read that are worth considering but are nobody's bug.
+
+- [ ] **The repeated map ending.** Chapters 45, 46, 48, 49, 50, 51, and 52 all close on the same
+      Gustaf map image with an identical caption — seven of the eight chapters in that span. The
+      framing around each one varies nicely; only the final beat repeats
+- [ ] **Chapter openings.** 28% of chapters (22 of 80) open with a participial recap phrase
+      ("Having defeated…", "After vanquishing…"). Effective, but better than one in four
+- [ ] **The round-robin has gone missing.** Giving every companion an interior beat in sequence is
+      the signature non-combat structure (ch. 42, 63, 67, 68, 76). Chapters 78–83 contain none
+- [ ] **Dialogue rate.** Ch. 78–83 run ~5% spoken words against a historical ~24%. Six consecutive
+      dungeon-crawl chapters with no talking chapter to reset is the anomaly, not any one chapter
+- [ ] **The pun/parody register is dormant.** Food Alley (ch. 19–21) is a whole comic mode —
+      Eclairvoyant's, The Fizz Hutt, Waffle Wizards — that hasn't been used since Elsemar

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -256,19 +256,6 @@ mid-melee — *"You really need a better skin care routine"* … *"It's a specia
 all-natural, organic ingredients that I apply twice a day."* Combat is where character comedy
 happens, not a break from it.
 
-## How combat gets drafted
-
-Five chapters (2, 3, 38, 39, 43) preserve `<!-- Step-by-step -->` beat sheets in comments — a
-mechanical list of who did what for how much damage — with the prose written from it afterward:
-
-```
-* Grindlefoot - Scoops up a handful of sand and casts Fog Cloud above their heads…
-* Mond - Casts his signature pink Lightning Bolt at one of the smaller soldiers, for 30 points
-  damage, killing them instantly.
-```
-
-If notes arrive in this shape, that's the source material. Narrate from it; don't reproduce it.
-
 ## Markers and devices
 
 - `_The group has learned the secret of X, …_` — italic, closes a secret-learned beat (ch. 65, 70, 71, 76)
@@ -361,6 +348,13 @@ Those five adverbs total roughly **30 per 10,000 words** — about one every twe
 drafted chapters cut the hedging verbs to near zero, which is a genuine improvement worth keeping.
 
 ## Abandoned experiments — don't revive
+
+- **List-form combat.** Combat was originally written as a bulleted list, one item per player's
+  turn per round. It was replaced by prose because prose reads far better. The
+  `<!-- Step-by-step -->` blocks in chapters 2, 3, 38, 39, and 43 are transitional residue from
+  that switch — the mechanical list moved into a comment while the prose was written from it.
+  **Do not create `<!-- Step-by-step -->` sections.** Combat goes straight to prose. The last use
+  of either form was chapter 43, forty chapters ago.
 
 - **Bulleted lists** appear in 20 chapters, nearly all before ch. 36 (loot tallies, mostly). You
   stopped, and the prose is better for it.

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -6,6 +6,11 @@ co-written by Tod and Claude. Supporting measurements draw on the full corpus, c
 Quotes below are verbatim from the repo. This file exists so the voice lives in the repo rather
 than in any one tool's memory.
 
+**Reading coverage.** Chapters 40–49 and 60–83 have been read in full. Chapters **50, 51, 52, 56,
+57, 58, and 59 have not** — 53–55 do not exist. Everything below is measured across all 83 chapters,
+but the qualitative observations come only from the chapters read. The unread run sits inside the
+puzzle/set-piece arc (ch. 41–52), so that section is the most likely to need expanding.
+
 ## The workflow that produced these
 
 From your own note in `2026-05-04-chapter-78.md`:

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -31,6 +31,26 @@ The break between 77 and 78 is sharp, and everything after 78 keeps the new shap
 
 Match the newer column on compression and paragraphing. **Do not match it on dialogue** — see below.
 
+## Your style was already moving
+
+Measured across all 80 chapters, two of the four shifts at ch. 78 are not a break at all — they are
+your own three-year trajectory, accelerated:
+
+| Chapters | words | dialogue % | sentence len | paragraph words |
+|---|---|---|---|---|
+| 1–20 | 1,653 | 14.7% | 19.5 | 77.5 |
+| 21–40 | 1,619 | 27.6% | 18.5 | 62.5 |
+| 41–60 | 2,338 | 18.8% | 17.3 | 48.5 |
+| 61–77 | 2,608 | 24.2% | 16.3 | 52.1 |
+| 78–83 | 2,045 | **5.2%** | 14.6 | 39.9 |
+
+Sentence length has fallen steadily since chapter 1 (r = −0.55) and so has paragraph length
+(r = −0.47). The drafted chapters continue both. But chapter length had been *growing* (r = +0.54)
+and dialogue *rising* (r = +0.18) — and 78–83 reverse both.
+
+The longest run of ≤10%-dialogue chapters anywhere before this was **4**, back at chapter 10. The
+drafted run is **6 consecutive**. That is the anomaly.
+
 ## Yours vs. Claude's
 
 Measured across the full 151,865-word pre-Claude corpus (chapters 1–77) against the drafted run.
@@ -102,8 +122,13 @@ Comedy and competence both come from character, never from the narrator:
   he'd give a timepiece whose mechanism had gone still."
 - **Mond** — showy, theatrical, a "predatory smirk." Occasionally says the tactless thing.
 
-First names only. No epithet-juggling — "the dwarf" and "the tiefling" appear, but sparingly, and
-never three different labels for one character in a paragraph.
+**Epithets are part of your voice, not a flaw to edit out.** "The dwarf," "the tiefling," "the
+half-orc," "the sorcerer" appear **411 times across chapters 56–77** — 71 per 10,000 words. The
+drafted chapters cut that to 24 per 10k, which is one reason they read as less like you.
+
+Use them. The failure mode to avoid isn't using an epithet, it's stacking three different labels
+for one character inside a single paragraph — Gven as "Gven," "the half-orc," and "the barbarian"
+in four sentences. One alternate label per character per paragraph, then back to the name.
 
 ## Combat
 
@@ -159,6 +184,55 @@ Chapters 81–82 build Dolor's parents-built-this-colossus thread across two ses
 remembered by name and their earlier behavior. Check the appendix
 (`_posts/2023-01-23-appendix.md`) for people, places, and history before inventing a detail.
 
+## Chapter openings
+
+**28% of chapters (22 of 80) open with a participial recap phrase** — "Having defeated the animated
+pastries…", "After vanquishing the gnolls…", "Standing in front of the entrance…", "Looking for any
+signs of weakness…". It's an effective "previously on" device and unmistakably yours, but at better
+than one chapter in four it has become predictable.
+
+Vary it. Chapters that open cold on an image or a line of dialogue are among the strongest in the
+run — ch. 31 opens on `"You're an interesting sight."`, ch. 63 on `"Pardon me, your brother?"`.
+
+## Endings
+
+**34% of chapters end on a line of dialogue.** That's your most consistent structural signature
+across all 80 chapters, and it's usually a joke or a character beat: "Where the fuck have you been,
+Torp?" / "Now I'm glazed and confused." / "Smells like barbeque." / "that wasn't optimal."
+
+Other endings in use: `_The adventurers advance to level N._` (10 chapters), `Long rest….`, and
+occasionally a closing image.
+
+Watch for repetition. **Chapters 45, 46, 48, 49, 50, 51, and 52 all end with the identical map
+image** — seven chapters in a row closing on the same caption. Whatever else varies, vary the last
+beat.
+
+## Crutches worth watching
+
+Measured across chapters 56–77. None of these are wrong; all are load-bearing enough to notice.
+
+| Crutch | Rate | Note |
+|---|---|---|
+| `suddenly` | 6.7 per 10k | Usually deletable — the event is already sudden |
+| `slowly` | 6.5 per 10k | |
+| `quickly` | 6.0 per 10k | |
+| `slightly` | 5.7 per 10k | Hedges the image it modifies |
+| `immediately` | 5.3 per 10k | |
+| `begins to` + verb | 7.3 per 10k | "begins to walk" → "walks" |
+| `seems to` | 5.4 per 10k | Hedge |
+| `appears to be` | 4.2 per 10k | Hedge |
+
+Those five adverbs total roughly **30 per 10,000 words** — about one every twelve sentences. The
+drafted chapters cut the hedging verbs to near zero, which is a genuine improvement worth keeping.
+
+## Abandoned experiments — don't revive
+
+- **Bulleted lists** appear in 20 chapters, nearly all before ch. 36 (loot tallies, mostly). You
+  stopped, and the prose is better for it.
+- **`<details>` collapsible blocks** appear only in chapters 25 and 28.
+- **The narrator addressing the reader** happens exactly once, in ch. 16: "_For brevity's sake, the
+  narrator has left out much of the dialog…_" Never repeated.
+
 ## Don't
 
 - Bulleted or summarized session recaps
@@ -166,4 +240,4 @@ remembered by name and their earlier behavior. Check the appendix
 - Dice numbers, hit points, or rules math in the prose
 - Second person, or any authorial aside to the reader
 - Narrating every single attack (that's the pre-78 mode)
-- Three synonyms for the same character in one paragraph
+- Three different labels for the same character inside one paragraph

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -526,8 +526,13 @@ drafted chapters cut the hedging verbs to near zero, which is a genuine improvem
 
 ## Abandoned experiments — don't revive
 
-- **List-form combat.** This was a much bigger and later thing than an earlier draft of this file
-  recorded, and the sequence ran the other way. The real history:
+- **List-form combat.** **All combat is prose. That is the standard for every chapter, including
+  the early ones.** The bulleted turn-by-turn lists still sitting in chapters 6–36 are not a style
+  to respect or preserve — they are an unrewritten backlog the author intends to convert to prose
+  and hasn't gotten to yet. Treat them as work not yet done, never as precedent.
+
+  With that established, the history is worth recording because it tells you which chapters need
+  the work. An earlier draft of this file had the sequence backwards:
 
   | Chapters | Combat form |
   |---|---|
@@ -536,17 +541,24 @@ drafted chapters cut the hedging verbs to near zero, which is a genuine improvem
   | 38, 39, 43 | Prose again, list demoted back into `<!-- Step-by-step -->` comments |
   | 44–83 | Prose only, mechanics entirely in comments |
 
-  Twenty chapters carry the rendered heading: 1, 6, 7, 8, 9, 10, 12, 13, 14, 17, 21, 25, 27, 29,
-  30, 31, 33, 35, 36, 38. Ch. 13's Battle of Wayside runs twelve numbered rounds as a pure list.
-  So the `<!-- Step-by-step -->` blocks at 38/39/43 are not residue of an abandoned start — they
-  are the **transition back out** of a thirty-chapter published-list era, the last stage before
-  the mechanics disappeared into comments for good.
+  So the `<!-- Step-by-step -->` blocks at 38/39/43 are the **transition out** of the list era —
+  the mechanics moving into comments while prose was written from them — not residue of an
+  abandoned start.
 
-  The conclusion is unchanged and now better supported: **prose won, and it is not close.** Ch. 13
-  as a list is unreadable next to ch. 35's jungle or ch. 38's grung fight. **Do not create
-  `<!-- Step-by-step -->` sections and never render mechanics on the page.** But know that the
-  early chapters look the way they do because that *was* the format, not because they were
-  drafts.
+  **The rewrite worklist.** Nineteen chapters still have rendered mechanics on the page and want
+  converting: **6, 7, 8, 9, 10, 12, 13, 14, 17, 21, 25, 27, 29, 30, 31, 33, 35, 36, 38.** (Ch. 1
+  has the `## Fight choreography` heading but its combat is already prose — it only needs the
+  heading dropped.) Ch. 13's Battle of Wayside is the biggest job: twelve numbered rounds, pure
+  list, no prose at all.
+
+  When converting, the model is ch. 38 — same fight, both forms, side by side in one file. The
+  comment says "Green grung 4 - Grapples Dolor and rubs his hands over Dolor's neck"; the prose
+  says the fourth creature "lands on Dolor's back, grabs hold tightly of his neck, and secretes a
+  slimy substance onto his skin," and later Dolor wonders where a naked frog was keeping a knife.
+  Keep the list in the comment as the working record, write the prose from it, drop the numbers.
+
+  **Never create `<!-- Step-by-step -->` sections in new work, and never render mechanics on the
+  page.**
 
   Two heading variants show the form was used for more than fights: `## Encounter choreography`
   (ch. 10, the stealth rescue of Vera from the hill giant) and `## Storm choreography` (ch. 30,

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -3,12 +3,16 @@
 Derived by reading chapters 60–77, written by Tod without assistance, and chapters 78–83,
 co-written by Tod and Claude. Supporting measurements draw on the full corpus, chapters 1–83.
 
+One exception to "written by Tod": **chapter 26 carries the comment `Originally written by Liam and
+edited by Tod`**, and Liam's raw session notes are preserved below it. It is the only chapter in
+1–77 with another author's hand in it, and it reads slightly differently — more past tense, more
+summary — which is worth knowing before treating it as a style sample.
+
 Quotes below are verbatim from the repo. This file exists so the voice lives in the repo rather
 than in any one tool's memory.
 
-**Reading coverage.** Chapters 40–52 and 56–83 have been read in full — 53–55 do not exist, so that
-is every chapter from 40 on. Chapters 1–39 have not been read; observations about them are
-measurements only. Everything below is measured across all 83 chapters.
+**Reading coverage.** All 83 chapters have now been read in full (53–55 do not exist). Everything
+below is both measured and read.
 
 ## The workflow that produced these
 
@@ -119,6 +123,15 @@ gives the Mac shortcut (Option + Shift + Dash), so this is a deliberate habit, n
 **Third person, present tense, always.** "Mond hangs from a rung of the ladder." Past tense only
 for things that already happened.
 
+This holds across all 83 chapters — I checked, expecting the early ones to drift, and they don't.
+Past-tense narration verbs sit near 7–11% of the total in every era of the campaign, including
+chapters 1–13. The exceptions are exactly what the rule predicts: **a sustained history or
+flashback passage goes fully past tense and then hands back.** Ch. 5's account of the Uprising and
+the founding of the Hands of the Wand, and ch. 63's flashback, are the clearest cases — each about
+half past tense, and each set off from the surrounding scene (ch. 5 puts it under its own italic
+heading, `### _The Uprising..._`). That's the move: don't half-shift inside a paragraph, shift
+wholesale for the whole passage and mark it.
+
 **Short paragraphs, and single-sentence paragraphs as punctuation.** These do real work:
 
 > Nothing happens.
@@ -142,6 +155,30 @@ flat, precise sentence about something absurd:
 > Mond fires at the last standing warforged and misses, his bolt going wide by enough that it's
 > almost impressive.
 
+**But dry understatement is the *late* register, not the only one.** The Elsemar chapters run on
+puns and parody, and they are funny. Food Alley (ch. 19–21) is built entirely out of it: **Dolly's
+Donuts**, **Eclairvoyant's Tea Shop**, **The Fizz Hutt**, and **Waffle Wizards** — a rundown
+stone castle with an iconic yellow sign, whose manager dreams of being promoted to the Beyond the
+Wall Grill or the Red Keep Bistro by the honchos at Game of Stones Restaurants. The jokes land on
+the beat:
+
+> "Do or donut, there is no try."
+
+> "Now I'm glazed and confused."
+
+> "Now, donut go causing too much a ruckus out there."
+
+Ch. 19 is the whole mode in miniature — **242 words**, the shortest chapter in the campaign. The
+party orders a dozen donuts, the donuts come alive and attack, Dolor eats the one that jumps into
+his mouth because blueberry jelly is his favorite, and it ends on the pun. That's it. It works
+because it doesn't overstay.
+
+Helper NPCs get pun names too: the tabaxi guide **Rightside** ("Rightside will do ya right!") and
+the tabaxi cartographer **Whichway** at a map shop called **The Four Corners**.
+
+This register mostly disappears after Elsemar. It doesn't have to. A pun chapter is a legitimate
+change of pace, and the campaign has gone a long time without one.
+
 **Dialogue carries the story.** In chapters 56–77, spoken words are **24% of the prose**. The
 characters talk — to each other, to NPCs, to corpses. Scenes advance through what people say.
 See the "Yours vs. Claude's" section below: this is the single biggest thing to protect.
@@ -160,6 +197,25 @@ Comedy and competence both come from character, never from the narrator:
 - **Dolor** — fastidious, analytical, keeps things to himself. Examines a dying warforged "the way
   he'd give a timepiece whose mechanism had gone still."
 - **Mond** — showy, theatrical, a "predatory smirk." Occasionally says the tactless thing.
+
+**The party in chapters 1–13 is not the party you know.** Bilwin and Mond do not exist yet. The
+founding four are Dolor, Gven, Grindlefoot, and **Xantic, a gnome artificer** — plus McGillicutty,
+the homunculus servant Xantic builds in ch. 7, who communicates only by pantomime and dances the
+Carlton. Xantic is the engine of the early comedy: he stabs his own foot to test a healing potion,
+blows up a child's doll with an eldritch cannon before anyone can stop him, cooks a "garbage
+omelet," and knocks himself unconscious on a table before the Battle of Wayside so he misses the
+whole thing.
+
+**Bilwin and Mond enter in ch. 14**, walking the Ha-derech as strangers to each other and to
+everyone else, arriving at Wayside just after the battle ends. In the same chapter Xantic leaves
+for good, staying behind to protect the town. That is the roster changing over inside one chapter,
+and it is handled entirely through scene — no announcement.
+
+The group name also moves: **"the Mixed Nuts"** (Gven coins it under pressure in ch. 2) becomes
+**"Chimera's Bane"** (Dolor renames them in ch. 7, waking from a dream). Grak still gets it wrong
+in ch. 14: *"Well done, Mixed Nuts! Oops, I mean huzzah, Chimera's Bane!"*
+
+When writing anything that reaches back before ch. 14, check who was actually there.
 
 **Epithets are part of your voice, not a flaw to edit out.** "The dwarf," "the tiefling," "the
 half-orc," "the sorcerer" appear **411 times across chapters 56–77** — 71 per 10,000 words. The
@@ -238,11 +294,27 @@ campaign. This is the hardest thing to imitate and the most important to get rig
 | The sphinx | Bored and deadpan; answers only what it was built to answer |
 | Dave Chevits | Fences with knitting needles; opens by disambiguating themself from David Shevitz |
 | Tham (Thamnoki Grumblebuster) | Heavy phonetic Scots, every line. "Ach, aye. This is whit I wis lookin' for! Cannae leave wi'oot some scran, noo can I." |
+| Cap'n Don Karnahge | Phonetic Scots plus delight in his own machinery. "It wirks! It really wirks!" Two rules on his ship, and rule one is "dinnae faw aff" |
+| Cindel | Self-mythologizing. "Huzzah!", a billowing cape, and a shaft of sunlight that finds her *and only her* on an overcast day |
+| Xantic | Gnome artificer, ch. 1–14. Curiosity with no brakes and no sense of consequence |
+| Rightside (tabaxi) | Helpful, eager, and derails mid-sentence whenever light catches something shiny — held consistently across ch. 16, 24, 26 |
+| Grak (goblin) | Takes offense at everything, wears no pants, and is deadly serious about both. "It's time for my pants." |
+| Hanseath, in person (ch. 32) | Spills half of every drink into his beard. "Dig deep enough, and the mountain's always there." Then: "Now, what the fuck are you doing?" |
+| Fred (half-orc pastry chef) | Slow, dry, delivers puns without acknowledging them |
 | Whelm (warhammer) | Telepathic, olde dwarven, single-minded about giants. "Aye, lad! Where them giants be hidin'?" |
 | Umberto Noblin | Gnome historian; answers a question by first listing his own book titles |
 | The water elemental (ch. 57) | Telegraphic pidgin, arriving through Dolor's translation. "No mood for fighting today. Friend offer escape, but tiny. No fit." |
 
 Give every new NPC one rule like this and hold it for every line they speak.
+
+**Phonetic Scots is your most-reused dialect, and it is getting crowded.** The tortle at the Hall
+of Records (ch. 16), Cap'n Don Karnahge (ch. 22–34), and Tham (ch. 52) are all written the same
+way, and Captain Inda's pirate is adjacent. Two of them carry working notes in the file — ch. 16
+links a Scots translator, ch. 34 keeps a plain-English version of Don's speech in a comment — so
+this is a deliberate tool, not an accident. It is effective and it is a lot of work to read. Before
+reaching for it a fifth time, give the new NPC a different axis: a rhythm (Gertrude's three-word
+sentences), a formatting tic (Redbud's `...one ...word ...at ...a ...time`), or a category error
+(404's error messages). Those distinguish an NPC without taxing the reader.
 
 Two of these are worth noting as a pattern in their own right: **magic items talk.** Whelm nags
 Bilwin through three straight chapters (50, 51, 52), always about giants, always at the wrong
@@ -299,10 +371,17 @@ and make the cost visible.
 
 ## Verse
 
-Prophecies and riddles are set as markdown blockquotes with `<br>` line breaks (ch. 20, 45, 47, 48,
+Prophecies and riddles are set as markdown blockquotes with `<br>` line breaks (ch. 45, 47, 48,
 50). The White Plume prophecy runs five stanzas. Gustaf's reaction is the model for how to undercut
 your own verse: *"the author could have used an editor. Evocative imagery and clear structure, but
 the cadence is uneven and phrasing repetitive."*
+
+The blockquote is not only for verse. Ch. 20 gives four full paragraphs of blockquote — no `<br>`,
+no line breaks — to Thistlewick Brandlestrum climbing onto a stool to deliver an unhinged oration
+about **kombucha**: "the elixir of the enlightened, the nectar of the ancients… a celestial tango
+of opposites that finds unity in your mouth." Nothing plot-relevant happens in it. It is a comic
+aria, and the blockquote is what marks it as a performance rather than dialogue. Use the form when
+a character delivers a set piece, not just when something rhymes.
 
 ## Banter inside combat
 
@@ -356,12 +435,33 @@ Housekeeping stays terse: `Long rest….`
 
 Guest players get a trailing italic credit: `_Guest player: Kimber Hilton as Mercy, the warforged_`
 
+The device starts at ch. 39 and has been used five times: ch. 39 and 42 (Nyx Whiskerfang, played by
+two *different* guest players — Chris Sells, then Kimber Hilton), ch. 47 (Dave Chevits), and ch. 77
+and 78 (Mercy). A recurring guest character surviving a change of player is worth remembering: the
+character belongs to the campaign, not to the guest.
+
 ## Continuity
 
 Reach back. Chapter 80 calls on the chimera, the kraken, and the Hertilod from the god's heart.
 Chapters 81–82 build Dolor's parents-built-this-colossus thread across two sessions. NPCs are
 remembered by name and their earlier behavior. Check the appendix
 (`_posts/2023-01-23-appendix.md`) for people, places, and history before inventing a detail.
+
+**Origins worth knowing, since the signature items all come from chapters 1–39:**
+
+- **Gleaming Blade** is looted off a goblin corpse in ch. 7 and mistaken for a rusty old sword;
+  Dolor attunes to it in ch. 9 and learns it belonged to a paladin.
+- **Tempest Edge** is a *gift* from **Veylara**, a storm giant, in ch. 32 — it is her boot dagger,
+  sister-forged to her own greatsword, and it is longer than Gven is tall. **This debt is still
+  open.** Gven promised to return the blade one day, and Veylara holds her family's Gruumsh
+  medallion — carved by Gven's father — as the counter-gift, worn as an earring. Any scene that
+  wants to land on Gven should know this exists.
+- **Bilwin's hurdy-gurdy** spends thirty chapters as a joke — he plays it terribly and mostly uses
+  the case as a club — until ch. 34 and 37, where he plays beautifully in Dwarven and only Gven
+  can understand the words. The instrument being genuinely good when it matters is a setup that
+  took a very long time to pay off.
+- **Torp is Davanor** (ch. 28), Gven's brother turned zealot, planning the genocide of every magic
+  user in Eritz. Gven's whole reason for being on the road in ch. 1 is looking for him.
 
 ## Chapter openings
 
@@ -426,12 +526,33 @@ drafted chapters cut the hedging verbs to near zero, which is a genuine improvem
 
 ## Abandoned experiments — don't revive
 
-- **List-form combat.** Combat was originally written as a bulleted list, one item per player's
-  turn per round. It was replaced by prose because prose reads far better. The
-  `<!-- Step-by-step -->` blocks in chapters 2, 3, 38, 39, and 43 are transitional residue from
-  that switch — the mechanical list moved into a comment while the prose was written from it.
-  **Do not create `<!-- Step-by-step -->` sections.** Combat goes straight to prose. The last use
-  of either form was chapter 43, forty chapters ago.
+- **List-form combat.** This was a much bigger and later thing than an earlier draft of this file
+  recorded, and the sequence ran the other way. The real history:
+
+  | Chapters | Combat form |
+  |---|---|
+  | 1–4 | Prose. Ch. 1 puts it under a rendered `## Fight choreography` heading; ch. 2–4 keep the mechanical list in `<!-- Step-by-step -->` comments and write prose from it |
+  | 6–36 | **Rendered bulleted lists were the published combat text** — one bullet per turn, damage numbers on the page, under a visible `## Fight choreography` H2 |
+  | 38, 39, 43 | Prose again, list demoted back into `<!-- Step-by-step -->` comments |
+  | 44–83 | Prose only, mechanics entirely in comments |
+
+  Twenty chapters carry the rendered heading: 1, 6, 7, 8, 9, 10, 12, 13, 14, 17, 21, 25, 27, 29,
+  30, 31, 33, 35, 36, 38. Ch. 13's Battle of Wayside runs twelve numbered rounds as a pure list.
+  So the `<!-- Step-by-step -->` blocks at 38/39/43 are not residue of an abandoned start — they
+  are the **transition back out** of a thirty-chapter published-list era, the last stage before
+  the mechanics disappeared into comments for good.
+
+  The conclusion is unchanged and now better supported: **prose won, and it is not close.** Ch. 13
+  as a list is unreadable next to ch. 35's jungle or ch. 38's grung fight. **Do not create
+  `<!-- Step-by-step -->` sections and never render mechanics on the page.** But know that the
+  early chapters look the way they do because that *was* the format, not because they were
+  drafts.
+
+  Two heading variants show the form was used for more than fights: `## Encounter choreography`
+  (ch. 10, the stealth rescue of Vera from the hill giant) and `## Storm choreography` (ch. 30,
+  eight rounds of the crew climbing masts in a gale). The storm one is genuinely effective as a
+  structure — a non-combat set piece with initiative and rounds — and is worth remembering as a
+  way to stage a group physical crisis, even though it should be written as prose now.
 
 - **Bulleted lists** appear in 18 chapters, all at ch. 36 or earlier (loot tallies, mostly). You
   stopped, and the prose is better for it — with **one deliberate exception**: ch. 58 sets out what
@@ -441,9 +562,30 @@ drafted chapters cut the hedging verbs to near zero, which is a genuine improvem
   the reader four plot facts they'll need later without a paragraph of throat-clearing. Reserve the
   form for that: notes, ledgers, and research the characters are reading — never for what the party
   did or what it looted.
-- **`<details>` collapsible blocks** appear only in chapters 25 and 28.
-- **The narrator addressing the reader** happens exactly once, in ch. 16: "_For brevity's sake, the
-  narrator has left out much of the dialog…_" Never repeated.
+- **`<details>` collapsible blocks** appear only in chapters 25 and 28 — and they are not a prose
+  device at all. They hold an author-facing *synopsis* of the chapter, bulleted, written when the
+  prose wasn't finished in time. Ch. 28 says so in a comment: "The following summary was
+  temporarily written up, giving me time to fully vet the conversation between Gven and Torp."
+  Useful to know as a stopgap; the two that shipped were never replaced with prose.
+
+- **The narrator addressing the reader** was recorded here as happening exactly once, in ch. 16
+  ("_For brevity's sake, the narrator has left out much of the dialog…_"). **That is wrong.** Ch.
+  16 is the most explicit instance, not the only one. Direct second person to the reader shows up
+  in narration at least four more times, all early:
+
+  > You note that the patrons treat the younger woman with respect, not the typical bawdiness you
+  > might encounter in such a crowd. *(ch. 2)*
+
+  > You don't mess with the Pride and Comfort without experiencing the consequences. *(ch. 5)*
+
+  > There are still plenty of ways to spend your hard-earned coin… *(ch. 22)*
+
+  > Rightside looks as you'd expect a wet cat to look. *(ch. 26)*
+
+  There is also a narrator's conspiratorial "…, mind you" in ch. 20, 24, 34, and once as late as
+  ch. 74. The habit fades after the Elsemar arc rather than stopping dead. **Still don't do it** —
+  the guidance was right even though the history wasn't — but don't be surprised to find it, and
+  don't "fix" it in an old chapter.
 
 ## Proofreading
 
@@ -454,6 +596,11 @@ times. Others that recur: `concious`, `acquiesence`, `irridescent`, `death throw
 None of it hurts the storytelling, and the voice is strong enough to carry them — but a spellcheck
 pass before publishing is the single cheapest improvement available. Watch `halfing` especially;
 spellcheck may not flag it.
+
+One a spellcheck will never catch: **Nyx's surname is spelled two ways.** Ch. 39's prose calls him
+"Nyx Whisperfang" four times, while its own guest-player credit — and ch. 41 and 42 — say
+"Whiskerfang." Whiskerfang is the one that stuck. Same class of error to watch for with any name
+introduced mid-fight.
 
 ## Don't
 

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -1,0 +1,169 @@
+# Writing voice
+
+Derived by reading chapters 78–83 (the Claude-drafted, hand-edited run) against chapter 77 (the
+last fully hand-written one). Quotes below are verbatim from the repo. This file exists so the
+voice lives in the repo rather than in any one tool's memory.
+
+## The workflow that produced these
+
+From your own note in `2026-05-04-chapter-78.md`:
+
+> This chapter was drafted by Claude. I had Claude review the 77 chapters I had written to
+> understand the storylines, characters, and my writing style. I dictated my notes into a Google
+> Doc, pasted that into Claude, and had it write a first draft, then a second. I manually edited
+> the final draft, putting my own touches and style on it.
+
+Two drafts, then your edit. The second draft matters — the first one gets the events down, the
+second one finds the beats. Don't hand over a first draft as though it's finished.
+
+## What changed at chapter 78
+
+The break between 77 and 78 is sharp, and everything after 78 keeps the new shape:
+
+| | Ch. 77 and earlier | Ch. 78 onward |
+|---|---|---|
+| Combat | Every attack narrated, round by round | Compressed; only what turns the scene |
+| Paragraphs | Dense, 5–8 lines | Short, often 1–3 sentences |
+| Line endings | Hard-wrapped at ~120 chars | No hard wrapping, one line per paragraph |
+| Em dash | Unspaced — `experience—and survival` | Spaced — `already made — it shows in their bearing` |
+| Emotional beats | Summarized | Given room, sometimes a full scene |
+| **Dialogue** | **24% of prose is spoken words** | **5%** |
+
+Match the newer column on compression and paragraphing. **Do not match it on dialogue** — see below.
+
+## Yours vs. Claude's
+
+Measured across the full 151,865-word pre-Claude corpus (chapters 1–77) against the drafted run.
+Not everything in 78–83 is your voice; some of it is LLM house style that survived editing.
+
+| Trait | Ch. 1–77 | Ch. 78–83 | Verdict |
+|---|---|---|---|
+| Spoken words as % of prose | 24.3% | 5.0% | **Regression — restore it** |
+| `the [expression/posture/grip] of someone who…` | 0 uses in 151k words | 4.1 per 10k | Claude's tic, not yours |
+| `the way a/one/you…` simile | 0.3 per 10k | 6.5 per 10k | Claude's, 20× amplified |
+| Spaced em dash ` — ` | **0** in 151k words | 27.7 per 10k | Claude's — you type unspaced |
+| Vague `something about/inside` | 0.3 per 10k | 7.3 per 10k | Claude's |
+| `kind of` hedging | 0.3 per 10k | 4.9 per 10k | Claude's |
+| `enough to/that` | 4.6 per 10k | 15.5 per 10k | Yours, over-amplified |
+| `as though` | 3.4 per 10k | 4.1 per 10k | Genuinely yours |
+| Mean sentence length | 16.3 words | 14.5 words | Improvement — keep |
+| `-ly` adverbs per 1k | 18.0 | 13.9 | Improvement — keep |
+
+**When drafting, actively suppress** the four "Claude's" rows and write dialogue near your
+historical rate. **Keep** the tighter sentences and lower adverb count — those are real gains.
+
+Em dashes are unspaced: `experience—and survival`. Your own reference note in the chapter files
+gives the Mac shortcut (Option + Shift + Dash), so this is a deliberate habit, not an accident.
+
+## Voice
+
+**Third person, present tense, always.** "Mond hangs from a rung of the ladder." Past tense only
+for things that already happened.
+
+**Short paragraphs, and single-sentence paragraphs as punctuation.** These do real work:
+
+> Nothing happens.
+
+> Then it stops.
+
+> One remains.
+
+> She sets the dead soldiers down gently.
+
+**Dry understatement is the comic register.** The humor is never the narrator winking — it's a
+flat, precise sentence about something absurd:
+
+> It is a good hole. He's proud of it already.
+
+> Bilwin raises his Mage Hand toward the blazebear with the optimism of someone who hasn't done
+> the arithmetic on the weight involved.
+
+> The stein misses, swinging through empty air with what can only be described as commitment.
+
+> Mond fires at the last standing warforged and misses, his bolt going wide by enough that it's
+> almost impressive.
+
+**Dialogue carries the story.** In chapters 56–77, spoken words are **24% of the prose**. The
+characters talk — to each other, to NPCs, to corpses. Scenes advance through what people say.
+See the "Yours vs. Claude's" section below: this is the single biggest thing to protect.
+
+## Characters
+
+Comedy and competence both come from character, never from the narrator:
+
+- **Bilwin** — curiosity that outruns caution; walks into things first. Casts spells by accident
+  and mostly gets away with it. Talks to the dead, badly. Never states a plan he hasn't already
+  started executing.
+- **Grindlefoot** — quiet competence, understated to the point of comedy. Digs a good hole. Reads
+  terrain. Saunters toward combat "at a pace that suggests he is deeply unconcerned."
+- **Gven** — direct, first through every door, and the narrative knows it costs her. She gets the
+  interior monologue when one is warranted.
+- **Dolor** — fastidious, analytical, keeps things to himself. Examines a dying warforged "the way
+  he'd give a timepiece whose mechanism had gone still."
+- **Mond** — showy, theatrical, a "predatory smirk." Occasionally says the tactless thing.
+
+First names only. No epithet-juggling — "the dwarf" and "the tiefling" appear, but sparingly, and
+never three different labels for one character in a paragraph.
+
+## Combat
+
+Narrate outcomes, never numbers. Initiative rolls, per-round damage, and fight choreography live
+in HTML comments; the prose says what happened in the world.
+
+Compress. A round is not five paragraphs — it's the two or three actions that changed something.
+Misses are worth a line only when the miss is characterful.
+
+Failure gets specifics: "the first strike misses, the second lands clean and hard across the
+warforged's midsection." Not "he attacks and hits."
+
+Spells and rules terms are inline links to D&D Beyond, described in-world rather than named
+mechanically where possible: "three crackling beams of energy," "a bolt of light," "his spiritual
+beer stein."
+
+**One interior beat per chapter, at most.** The model is Gven's paragraph in chapter 80 — a
+mid-combat recollection of the chimera, the kraken, the Hertilod, landing on "And this creature
+chose the wrong barbarian." It earns the kill that follows. Overusing this would wreck it.
+
+## Emotional scenes
+
+Slow down and cut the sentences shorter. The Mercy/Filch reunion in chapter 78 is the high-water
+mark: "No one speaks." / "Mercy stays there for a long time." / "The companions wait without
+fidgeting, without filling the silence."
+
+Let silence be described rather than filled. Then undercut it — that scene ends on "Mercy. Where
+the hell have you been?"
+
+## Chapter shape
+
+**Open mid-motion**, continuing directly from the previous chapter's final beat. 79 opens in the
+quiet after Filch's revival; 81 opens with Dolor still pinned under the blazebear.
+
+**Close on a button** — a joke, a reveal, or an image that hangs:
+
+> It lands directly on Dolor.
+
+> "Mercy. Where the hell have you been?"
+
+> The woman on the bunk doesn't move.
+
+Scene breaks are `---` on its own line, used freely — chapters 78–83 average five or six.
+
+Housekeeping stays terse: `Long rest….`
+
+Guest players get a trailing italic credit: `_Guest player: Kimber Hilton as Mercy, the warforged_`
+
+## Continuity
+
+Reach back. Chapter 80 calls on the chimera, the kraken, and the Hertilod from the god's heart.
+Chapters 81–82 build Dolor's parents-built-this-colossus thread across two sessions. NPCs are
+remembered by name and their earlier behavior. Check the appendix
+(`_posts/2023-01-23-appendix.md`) for people, places, and history before inventing a detail.
+
+## Don't
+
+- Bulleted or summarized session recaps
+- "The party decides to…" — characters act, groups don't deliberate on the page
+- Dice numbers, hit points, or rules math in the prose
+- Second person, or any authorial aside to the reader
+- Narrating every single attack (that's the pre-78 mode)
+- Three synonyms for the same character in one paragraph

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -145,9 +145,70 @@ Spells and rules terms are inline links to D&D Beyond, described in-world rather
 mechanically where possible: "three crackling beams of energy," "a bolt of light," "his spiritual
 beer stein."
 
-**One interior beat per chapter, at most.** The model is Gven's paragraph in chapter 80 — a
-mid-combat recollection of the chimera, the kraken, the Hertilod, landing on "And this creature
-chose the wrong barbarian." It earns the kill that follows. Overusing this would wreck it.
+A mid-combat interior beat is allowed and effective — Gven's paragraph in chapter 80 recalls the
+chimera, the kraken, and the Hertilod before landing on "And this creature chose the wrong
+barbarian," earning the kill that follows. One per fight is plenty.
+
+## The round-robin — your signature structure
+
+Outside combat, the move that recurs more than any other is **giving every companion an interior
+beat in sequence**, one short section each:
+
+- **Ch. 63** — four dreams after the first night in Lord Neverwinter's manor
+- **Ch. 67** — five bath scenes, one per character, each surfacing a private preoccupation
+- **Ch. 68** — four dream recollections, capped by Mond's joke that he slept fine
+- **Ch. 76** — the warforged each answer "did you choose your name, or was it given?"
+
+This is where the campaign's emotional continuity lives: Bilwin's lost dwarven company, Gven's
+brother, Mond's freedom to use magic openly, Grindlefoot's spider-self, Dolor's parents' workshop.
+Combat advances plot; the round-robin advances character.
+
+Use it at every rest, arrival, or downtime beat. Vary the frame — dreams, baths, a shared question,
+a quiet evening around Dolor's glory hole. Chapters 78–83 contain **none** of these, which is a
+bigger loss than the dialogue drop.
+
+## Non-combat chapters are a mode, not a gap
+
+Chapters 63, 74, and 75 have essentially no fighting and are among the strongest in the run: the
+two months settling into Neverwinter and the arrival of Eva Brightbroom; Tasha turning Gven into a
+goldfish and letting her suffocate to teach her manners; Grindlefoot scrying his garden through a
+potato; Bilwin's three yes-or-no questions to a drunk Hanseath.
+
+Don't treat a session light on combat as a thin chapter. It's an opportunity.
+
+## NPC voice is the craft
+
+Every named NPC gets a distinct verbal signature, and they're the most memorable thing in the
+campaign. This is the hardest thing to imitate and the most important to get right:
+
+| NPC | Register |
+|---|---|
+| Gertrude (cyclops) | Three-to-five-word sentences. "I'll smash for you!" "Mine." "Go find friend. After smash." |
+| Redbud (treant) | `...One ...word ...at ...a ...time`, literally typed that way |
+| Ikasa (blink dog) | Excited fragments, dog logic. "You smell like fire. I like it." |
+| 404 (warforged) | Error messages. "Name not found!" "Purpose found!" |
+| Captain Inda | Heavy phonetic pirate. "Aye, so might a skulking bilge-rat…" |
+| Tasha | Arch and camp. "Speak for yourself, darling. Some of us are _always_ fabulous." |
+| Eva Brightbroom | Mary Poppins, never once acknowledged. "I never explain anything." |
+| Hanseath | Drunk god who breaks the fourth wall on game rules |
+| Maltok | Flat, literal telepathy. "Feels sturdy. It would work in battle. And kill fish." |
+
+Give every new NPC one rule like this and hold it for every line they speak.
+
+## Markers and devices
+
+- `_The group has learned the secret of X, …_` — italic, closes a secret-learned beat (ch. 65, 70, 71, 76)
+- `_The adventurers advance to level N._` — italic, ends the chapter
+- `Long rest....` / `Short rest....` — four dots, on its own line
+- `_Guest player: Name as Character_` — italic credit at the end
+- Player-drawn maps embedded as images, credited to Mond or Gustaf
+
+## Profanity
+
+Used sparingly and always as a punchline or a pressure release, never as texture. "Well, fuck."
+ends chapter 63. Elden shrugs "Fuck you all" and jumps into a portal. Kycera's "Get that fucker!"
+launches a fight. Grindlefoot's "Do you want to fuck yarn or do you want this?" is the biggest
+laugh in the run. Keep it rare enough that it lands.
 
 ## Emotional scenes
 
@@ -232,6 +293,16 @@ drafted chapters cut the hedging verbs to near zero, which is a genuine improvem
 - **`<details>` collapsible blocks** appear only in chapters 25 and 28.
 - **The narrator addressing the reader** happens exactly once, in ch. 16: "_For brevity's sake, the
   narrator has left out much of the dialog…_" Never repeated.
+
+## Proofreading
+
+Chapters 60–77 carry roughly 48 recurring misspellings. `halfing` for `halfling` alone appears 11
+times. Others that recur: `concious`, `acquiesence`, `irridescent`, `death throws` (for "throes"),
+`occured`, `catastrophy`, `posessions`, `accomodations`, `demeaner`, `respit`.
+
+None of it hurts the storytelling, and the voice is strong enough to carry them — but a spellcheck
+pass before publishing is the single cheapest improvement available. Watch `halfing` especially;
+spellcheck may not flag it.
 
 ## Don't
 

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -1,8 +1,10 @@
 # Writing voice
 
-Derived by reading chapters 78–83 (the Claude-drafted, hand-edited run) against chapter 77 (the
-last fully hand-written one). Quotes below are verbatim from the repo. This file exists so the
-voice lives in the repo rather than in any one tool's memory.
+Derived by reading chapters 60–77, written by Tod without assistance, and chapters 78–83,
+co-written by Tod and Claude. Supporting measurements draw on the full corpus, chapters 1–83.
+
+Quotes below are verbatim from the repo. This file exists so the voice lives in the repo rather
+than in any one tool's memory.
 
 ## The workflow that produced these
 

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -292,7 +292,7 @@ campaign. This is the hardest thing to imitate and the most important to get rig
 | Gustaf Mondalbrot | Verbose archaeologist; digresses, name-drops his own adventures, undercuts himself |
 | Nyx (tabaxi) | Laconic, dry. "I got hungry." Feline tells slipped in — a purr, a lope |
 | The sphinx | Bored and deadpan; answers only what it was built to answer |
-| Dave Chevits | Fences with knitting needles; opens by disambiguating themself from David Shevitz |
+| Dave Chevits | Fences with knitting needles; opens by disambiguating themself from David Shevitz. **This is a disguise** — see below |
 | Tham (Thamnoki Grumblebuster) | Heavy phonetic Scots, every line. "Ach, aye. This is whit I wis lookin' for! Cannae leave wi'oot some scran, noo can I." |
 | Cap'n Don Karnahge | Phonetic Scots plus delight in his own machinery. "It wirks! It really wirks!" Two rules on his ship, and rule one is "dinnae faw aff" |
 | Cindel | Self-mythologizing. "Huzzah!", a billowing cape, and a shaft of sunlight that finds her *and only her* on an overcast day |
@@ -316,10 +316,17 @@ reaching for it a fifth time, give the new NPC a different axis: a rhythm (Gertr
 sentences), a formatting tic (Redbud's `...one ...word ...at ...a ...time`), or a category error
 (404's error messages). Those distinguish an NPC without taxing the reader.
 
-Two of these are worth noting as a pattern in their own right: **magic items talk.** Whelm nags
+**Dave Chevits is not a person.** The appendix records that the knitting halfling locked under the
+ziggurat in ch. 47 is **Fenseck**, the efreeti/djinni who granted Dolor his warlock powers, wearing
+a disguise. That means the funniest NPC introduction in the run is also a patron quietly inspecting
+his own warlock, and any later scene with Fenseck can reach back to it. Don't write Dave Chevits as
+a one-off gag character — he isn't one.
+
+Three of these are worth noting as a pattern in their own right: **magic items talk.** Whelm nags
 Bilwin through three straight chapters (50, 51, 52), always about giants, always at the wrong
-moment. Wave introduces itself to Dolor with four words and nothing else: *"I am Wave."* A sentient
-item gets the same treatment as an NPC — one rule, held.
+moment. Wave introduces itself to Dolor with four words and nothing else: *"I am Wave."* And
+**Blackrazor** (ch. 47) completes the set — the three sentient weapons of White Plume Mountain, all
+recovered, all talkative. A sentient item gets the same treatment as an NPC: one rule, held.
 
 Bilwin's running gags recur across chapters and should be reached for rather than reinvented.
 Ch. 56 has him spelling out "sar-kay-oh-ef-uh-guy" so the wights won't know what the party is
@@ -446,6 +453,29 @@ Reach back. Chapter 80 calls on the chimera, the kraken, and the Hertilod from t
 Chapters 81–82 build Dolor's parents-built-this-colossus thread across two sessions. NPCs are
 remembered by name and their earlier behavior. Check the appendix
 (`_posts/2023-01-23-appendix.md`) for people, places, and history before inventing a detail.
+
+**Trust the appendix, but not blindly.** It is the reference of record and it is thorough — 100+
+named characters, every shop and road, the magic items with their full mechanics. Five things in it
+are known to be wrong or stale as of this writing, so verify against the chapter before repeating
+any of them:
+
+- **Eyes of the Star and Hand of the Wand have their descriptions swapped.** Ch. 5 is explicit:
+  Hands of the Wand track *magic users* and are magic users themselves; Eyes of the Star monitor
+  *religious* groups. The appendix says the reverse. The names side with ch. 5 — wand, arcane.
+- **"Everwinter" should be "Evernight."** Ch. 59, 60, and 63 all say Evernight, and so does ch.
+  59's tag. Only the appendix says Everwinter.
+- **The Davanor entry is stale** — "unknown gender and species… person of interest in Torp's
+  disappearance." Ch. 28 revealed Davanor *is* Torp. The two are still separate entries in separate
+  sections.
+- **Seven entries link to chapters 53, 54, and 55, which don't exist** (see below).
+- **Cindel** is "half-elven" in the appendix but "elf" every time she appears in ch. 1–4.
+
+**Chapters 53–55 are unwritten sessions, not a numbering skip.** The appendix documents things
+that happened in them — Maelis Varn, the Gilded Glyph, the Fucking Duck, Hallix Mausoleum, the
+party meeting Alustriel Silverhand — and ch. 56 opens with "The adventurers leave The Gilded
+Glyph," a shop the reader has never seen. Those seven appendix links are 404s on the live site.
+If a chapter ever needs to reach back to the arrival in Neverwinter, the appendix is currently the
+only account of it.
 
 **Origins worth knowing, since the signature items all come from chapters 1–39:**
 

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -20,18 +20,40 @@ second one finds the beats. Don't hand over a first draft as though it's finishe
 
 ## What changed at chapter 78
 
-The break between 77 and 78 is sharp, and everything after 78 keeps the new shape:
+Not a clean break. Chapter 78 is a hinge, but only some of what shifted there is real, and almost
+none of it is an improvement to copy wholesale.
 
-| | Ch. 77 and earlier | Ch. 78 onward |
+**Genuine reversals — these are what to fix:**
+
+| | Ch. 61–77 | Ch. 78–83 |
 |---|---|---|
-| Combat | Every attack narrated, round by round | Compressed; only what turns the scene |
-| Paragraphs | Dense, 5–8 lines | Short, often 1–3 sentences |
-| Line endings | Hard-wrapped at ~120 chars | No hard wrapping, one line per paragraph |
-| Em dash | Unspaced — `experience—and survival` | Spaced — `already made — it shows in their bearing` |
-| Emotional beats | Summarized | Given room, sometimes a full scene |
-| **Dialogue** | **24% of prose is spoken words** | **5%** |
+| Spoken words as % of prose | 24.3% | **5.0%** |
+| Round-robin interior sequences | ch. 63, 67, 68, 76 | **none** |
+| Chapters with little or no combat | ch. 63, 74, 75 | **none** — all six are dungeon crawl |
+| Words per chapter | 2,608 | 2,045 |
+| Spaced em dash ` — ` | 0 in 151k words | 27.7 per 10k |
 
-Match the newer column on compression and paragraphing. **Do not match it on dialogue** — see below.
+Each of these runs *against* your own trajectory. Chapter length had been growing (r = +0.54) and
+dialogue rising (r = +0.18) across the whole campaign.
+
+**Continuations, not breaks** — you were already heading here, so there is nothing to undo:
+
+- Sentence length 16.3 → 14.5 words, extending a decline since chapter 1 (r = −0.55)
+- Paragraph length 52.1 → 39.9 words, extending a decline since chapter 1 (r = −0.47)
+- `-ly` adverbs 18.0 → 13.9 per 1,000 words
+- Hedging verbs (`begins to`, `seems to`, `appears to be`) cut to near zero — a real gain
+
+**Overstated.** Combat compression is real but modest: 578 words per round in ch. 61–77 versus 415
+in 78–83, a 28% reduction rather than a categorical change. Chapter 78 itself runs 744 words per
+round, the densest in the recent run.
+
+**Not stylistic at all.** The hard-wrapping change (your lines wrap near 120 characters; the drafted
+files run one long line per paragraph) is an artifact of pasting out of a chat window.
+
+**Wrong in an earlier draft of this file, corrected here:** emotional beats were *not* previously
+summarized. Chapters 63, 66, 67, 68, and 74 give them more room than anything in 78–83 — five bath
+scenes, a childhood flashback with Torp, Grindlefoot's whole farming backstory. What 78–83 has is
+one very good scene (Mercy and Filch) and no round-robins at all.
 
 ## Your style was already moving
 

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -6,10 +6,9 @@ co-written by Tod and Claude. Supporting measurements draw on the full corpus, c
 Quotes below are verbatim from the repo. This file exists so the voice lives in the repo rather
 than in any one tool's memory.
 
-**Reading coverage.** Chapters 40–49 and 60–83 have been read in full. Chapters **50, 51, 52, 56,
-57, 58, and 59 have not** — 53–55 do not exist. Everything below is measured across all 83 chapters,
-but the qualitative observations come only from the chapters read. The unread run sits inside the
-puzzle/set-piece arc (ch. 41–52), so that section is the most likely to need expanding.
+**Reading coverage.** Chapters 40–52 and 56–83 have been read in full — 53–55 do not exist, so that
+is every chapter from 40 on. Chapters 1–39 have not been read; observations about them are
+measurements only. Everything below is measured across all 83 chapters.
 
 ## The workflow that produced these
 
@@ -79,6 +78,17 @@ and dialogue *rising* (r = +0.18) — and 78–83 reverse both.
 
 The longest run of ≤10%-dialogue chapters anywhere before this was **4**, back at chapter 10. The
 drafted run is **6 consecutive**. That is the anomaly.
+
+**But dialogue rate tracks mode, not just era.** Reading the dungeon-crawl chapters confirms it:
+ch. 51 (the turnstile, the drain valve, the spinning cylinder) runs about 9% dialogue and ch. 59
+(the Vecna vision and the ghoul pit) about 8% — both as low as anything in 78–83, both written by
+you alone. Ch. 57, which is mostly the party talking to a water elemental and to Umberto, runs
+about 22% in the same arc.
+
+So a chapter that is one long corridor of rooms and fights will come in low, and that is fine. What
+78–83 did was string **six** of them together with no talking chapter in between to reset. The fix
+is not to force dialogue into a dungeon chapter — it's to make sure a dungeon run is broken up by a
+Sarcelle, an Umberto, or a Tham.
 
 ## Yours vs. Claude's
 
@@ -227,8 +237,21 @@ campaign. This is the hardest thing to imitate and the most important to get rig
 | Nyx (tabaxi) | Laconic, dry. "I got hungry." Feline tells slipped in — a purr, a lope |
 | The sphinx | Bored and deadpan; answers only what it was built to answer |
 | Dave Chevits | Fences with knitting needles; opens by disambiguating themself from David Shevitz |
+| Tham (Thamnoki Grumblebuster) | Heavy phonetic Scots, every line. "Ach, aye. This is whit I wis lookin' for! Cannae leave wi'oot some scran, noo can I." |
+| Whelm (warhammer) | Telepathic, olde dwarven, single-minded about giants. "Aye, lad! Where them giants be hidin'?" |
+| Umberto Noblin | Gnome historian; answers a question by first listing his own book titles |
+| The water elemental (ch. 57) | Telegraphic pidgin, arriving through Dolor's translation. "No mood for fighting today. Friend offer escape, but tiny. No fit." |
 
 Give every new NPC one rule like this and hold it for every line they speak.
+
+Two of these are worth noting as a pattern in their own right: **magic items talk.** Whelm nags
+Bilwin through three straight chapters (50, 51, 52), always about giants, always at the wrong
+moment. Wave introduces itself to Dolor with four words and nothing else: *"I am Wave."* A sentient
+item gets the same treatment as an NPC — one rule, held.
+
+Bilwin's running gags recur across chapters and should be reached for rather than reinvented.
+Ch. 56 has him spelling out "sar-kay-oh-ef-uh-guy" so the wights won't know what the party is
+after, and the joke gets picked up twice more in the same chapter, including as its closing line.
 
 ## Puzzle and set-piece chapters
 
@@ -241,11 +264,38 @@ some of the most inventive writing in the run:
   walks into a pit: *"There's a pit down that passage."*
 - Golems numbered 5, 7, 9, 11, 13 — pick the one that doesn't belong, ch. 48
 - Nine orbs, one real key, ch. 49
-- Timing two geysers on a 5-minute and 3-minute cycle to cross hanging discs, ch. 49–50
+- Timing two geysers on a 5-minute and 3-minute cycle to cross hanging discs, ch. 49
+- A one-way turnstile with no reverse, ch. 51
+- A ten-foot pool with a valve wheel at the bottom that drains the level, ch. 51
+- A thirty-foot spinning cylinder painted like a barber's pole, greased, with a fire trap that
+  triggers on contact, ch. 51
+- A translucent bubble holding back a cavern of boiling water, with a giant crab guarding the
+  trident Wave in the sand at its center, ch. 52
 
-Write the solution as a character thinking aloud, not as narration explaining. Dolor gets "I think
-it's more complex, most likely an exclusive binary operation"; Mond asks for ten minutes and comes
-back with the pattern.
+**Two solution modes, and the second is at least as common as the first.**
+
+*Solved.* A character reasons it out aloud, and the reasoning is the scene — not narration
+explaining it afterward. Dolor gets "I think it's more complex, most likely an exclusive binary
+operation"; Mond asks for ten minutes and comes back with "the geyser closest to us erupts every
+5 minutes… and the geyser on the far side, every 3."
+
+*Bypassed.* Just as often the party refuses the puzzle on its own terms and goes around it with an
+ability or with muscle — and the writing gets its comedy from **what the bypass costs**:
+
+- Ch. 50 abandons the geyser timing entirely once the rope is destroyed. Grindlefoot wild-shapes
+  into a giant spider and ferries everyone across the ceiling in butt-yarn. It works — except
+  Golem Number 9 is too heavy, the webbing snaps, and the golem sinks into the boiling mud, calm
+  the whole way down, waving at Gustaf before it goes under.
+- Ch. 51 answers the turnstile with Mond freezing it brittle and Gven and Dolor snapping it, which
+  leaves her slumped on the floor in exhaustion.
+- Ch. 51 answers the spinning cylinder with Dolor simply going in — he slips, ends up prone, the
+  floor bursts into flame under him, and he rolls out the far end. "If it's not a rope it's
+  something else."
+
+Neither mode is the correct one. The bypass is not a failure state to write around: it produces
+Grindlefoot's spider ferry and Dolor's second bad experience with being tied to things, and those
+are better scenes than a clean solve would have been. Write whichever one the table actually did,
+and make the cost visible.
 
 ## Verse
 
@@ -263,7 +313,9 @@ happens, not a break from it.
 
 ## Markers and devices
 
-- `_The group has learned the secret of X, …_` — italic, closes a secret-learned beat (ch. 65, 70, 71, 76)
+- `_The group has learned the secret of X, …_` — italic, closes a secret-learned beat. First used in
+  ch. 56, then 57, 65, 70, 71, 76. The `secret-learned` tag is on one more chapter than the marker
+  is (ch. 59, where the party receives Vecna's gift but no italic line closes it)
 - `_The adventurers advance to level N._` — italic, ends the chapter
 - `Long rest....` / `Short rest....` — four dots, on its own line
 - `_Guest player: Name as Character_` — italic credit at the end
@@ -330,9 +382,16 @@ Torp?" / "Now I'm glazed and confused." / "Smells like barbeque." / "that wasn't
 Other endings in use: `_The adventurers advance to level N._` (10 chapters), `Long rest….`, and
 occasionally a closing image.
 
-Watch for repetition. **Chapters 45, 46, 48, 49, 50, 51, and 52 all end with the identical map
-image** — seven chapters in a row closing on the same caption. Whatever else varies, vary the last
-beat.
+Watch for repetition. **Chapters 45, 46, 48, 49, 50, 51, and 52 all end with the same map image and
+the identical caption** — seven of the eight chapters in that span. (Ch. 47 carries the map too but
+ends on a guest-player credit instead, and ch. 43 and 44 break the run before it starts.) Whatever
+else varies, vary the last beat.
+
+The framing device around those maps does vary, and that's what saves them: Gustaf sits down to
+update the map while the others rest (ch. 50), narrates his own enthusiasm (ch. 51), or hides in the
+entry passage insisting the party surely has the giant crab under control (ch. 52). In ch. 50 the
+map beat carries real weight — Gustaf is quietly mourning Golem Number 9, the "kindred cartography
+spirit" who drowned in the mud an hour earlier.
 
 ## Crutches worth watching
 
@@ -348,6 +407,19 @@ Measured across chapters 56–77. None of these are wrong; all are load-bearing 
 | `begins to` + verb | 7.3 per 10k | "begins to walk" → "walks" |
 | `seems to` | 5.4 per 10k | Hedge |
 | `appears to be` | 4.2 per 10k | Hedge |
+| `the group/party/companions decides` | 25 uses, 24 chapters | See below |
+
+**Correction to an earlier draft of this file:** "the party decides to…" was listed as a *don't*,
+on the reasoning that characters act and groups don't deliberate on the page. That is not supported
+by the corpus. The construction appears about 25 times across 24 chapters, spread evenly from ch. 3
+to ch. 80 — including in the drafted run. It is a genuine, low-frequency habit, roughly one use
+every three chapters, not a foreign tic.
+
+It is still worth watching, because it does flatten a beat when the alternative was available. Ch.
+51's "The rest of the party decides to remain on the original side" is the weak form. Ch. 58's
+answer to the same problem is the strong one: "Gven votes with her feet, opening the previously
+hidden door in the south wall" — a character settles the group's decision by acting, and the
+sentence is funnier for it. Prefer that when it's within reach. Don't hunt down every instance.
 
 Those five adverbs total roughly **30 per 10,000 words** — about one every twelve sentences. The
 drafted chapters cut the hedging verbs to near zero, which is a genuine improvement worth keeping.
@@ -361,8 +433,14 @@ drafted chapters cut the hedging verbs to near zero, which is a genuine improvem
   **Do not create `<!-- Step-by-step -->` sections.** Combat goes straight to prose. The last use
   of either form was chapter 43, forty chapters ago.
 
-- **Bulleted lists** appear in 20 chapters, nearly all before ch. 36 (loot tallies, mostly). You
-  stopped, and the prose is better for it.
+- **Bulleted lists** appear in 18 chapters, all at ch. 36 or earlier (loot tallies, mostly). You
+  stopped, and the prose is better for it — with **one deliberate exception**: ch. 58 sets out what
+  Dolor finds in the necromancer's marginalia as a four-item list (the tangible quality of secrets,
+  the siphoning ritual, the first test subject, the Crevices of Dusk). That one earns it. A list of
+  *discovered documents* reads as the party's findings rather than as a session log, and it hands
+  the reader four plot facts they'll need later without a paragraph of throat-clearing. Reserve the
+  form for that: notes, ledgers, and research the characters are reading — never for what the party
+  did or what it looted.
 - **`<details>` collapsible blocks** appear only in chapters 25 and 28.
 - **The narrator addressing the reader** happens exactly once, in ch. 16: "_For brevity's sake, the
   narrator has left out much of the dialog…_" Never repeated.
@@ -380,7 +458,6 @@ spellcheck may not flag it.
 ## Don't
 
 - Bulleted or summarized session recaps
-- "The party decides to…" — characters act, groups don't deliberate on the page
 - Dice numbers, hit points, or rules math in the prose
 - Second person, or any authorial aside to the reader
 - Narrating every single attack (that's the pre-78 mode)

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -178,6 +178,8 @@ barbarian," earning the kill that follows. One per fight is plenty.
 Outside combat, the move that recurs more than any other is **giving every companion an interior
 beat in sequence**, one short section each:
 
+- **Ch. 42** — each companion says why they're really on this journey, capped by Grindlefoot's
+  "I'm looking for tasty nuts, really, that's about it"
 - **Ch. 63** — four dreams after the first night in Lord Neverwinter's manor
 - **Ch. 67** — five bath scenes, one per character, each surfacing a private preoccupation
 - **Ch. 68** — four dream recollections, capped by Mond's joke that he slept fine
@@ -216,8 +218,56 @@ campaign. This is the hardest thing to imitate and the most important to get rig
 | Eva Brightbroom | Mary Poppins, never once acknowledged. "I never explain anything." |
 | Hanseath | Drunk god who breaks the fourth wall on game rules |
 | Maltok | Flat, literal telepathy. "Feels sturdy. It would work in battle. And kill fish." |
+| Gustaf Mondalbrot | Verbose archaeologist; digresses, name-drops his own adventures, undercuts himself |
+| Nyx (tabaxi) | Laconic, dry. "I got hungry." Feline tells slipped in — a purr, a lope |
+| The sphinx | Bored and deadpan; answers only what it was built to answer |
+| Dave Chevits | Fences with knitting needles; opens by disambiguating themself from David Shevitz |
 
 Give every new NPC one rule like this and hold it for every line they speak.
+
+## Puzzle and set-piece chapters
+
+A whole mode the Mournland arc has little of. Chapters 41–52 are built around them, and they're
+some of the most inventive writing in the run:
+
+- The seasons door in ch. 41, solved as an exclusive-binary operation
+- Offerings placed in a god's four open hands, ch. 42
+- The sphinx's riddle at the three-way junction, ch. 45 — and its deadpan follow-up after the party
+  walks into a pit: *"There's a pit down that passage."*
+- Golems numbered 5, 7, 9, 11, 13 — pick the one that doesn't belong, ch. 48
+- Nine orbs, one real key, ch. 49
+- Timing two geysers on a 5-minute and 3-minute cycle to cross hanging discs, ch. 49–50
+
+Write the solution as a character thinking aloud, not as narration explaining. Dolor gets "I think
+it's more complex, most likely an exclusive binary operation"; Mond asks for ten minutes and comes
+back with the pattern.
+
+## Verse
+
+Prophecies and riddles are set as markdown blockquotes with `<br>` line breaks (ch. 20, 45, 47, 48,
+50). The White Plume prophecy runs five stanzas. Gustaf's reaction is the model for how to undercut
+your own verse: *"the author could have used an editor. Evocative imagery and clear structure, but
+the cadence is uneven and phrasing repetitive."*
+
+## Banter inside combat
+
+Fights are not tonally sealed off. In ch. 47 a black knight and Gven trade skincare advice
+mid-melee — *"You really need a better skin care routine"* … *"It's a special compound of
+all-natural, organic ingredients that I apply twice a day."* Combat is where character comedy
+happens, not a break from it.
+
+## How combat gets drafted
+
+Five chapters (2, 3, 38, 39, 43) preserve `<!-- Step-by-step -->` beat sheets in comments — a
+mechanical list of who did what for how much damage — with the prose written from it afterward:
+
+```
+* Grindlefoot - Scoops up a handful of sand and casts Fog Cloud above their heads…
+* Mond - Casts his signature pink Lightning Bolt at one of the smaller soldiers, for 30 points
+  damage, killing them instantly.
+```
+
+If notes arrive in this shape, that's the source material. Narrate from it; don't reproduce it.
 
 ## Markers and devices
 

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -1,18 +1,18 @@
 # Writing voice
 
-Derived by reading chapters 60–77, written by Tod without assistance, and chapters 78–83,
-co-written by Tod and Claude. Supporting measurements draw on the full corpus, chapters 1–83.
+**Derived by reading all 83 chapters in full**, plus the appendix — the complete campaign, ch. 1
+through 83. (Chapters 53–55 do not exist; they were sessions that never got written up.) Every
+observation below is both read and measured, and quotes are verbatim from the repo.
 
-One exception to "written by Tod": **chapter 26 carries the comment `Originally written by Liam and
-edited by Tod`**, and Liam's raw session notes are preserved below it. It is the only chapter in
-1–77 with another author's hand in it, and it reads slightly differently — more past tense, more
-summary — which is worth knowing before treating it as a style sample.
+Chapters 1–77 are written by Tod; chapters 78–83 are co-written by Tod and Claude. **One exception:
+chapter 26 carries the comment `Originally written by Liam and edited by Tod`**, with Liam's raw
+session notes preserved below it. It is the only chapter in 1–77 with another author's hand in it,
+and it reads slightly differently — more past tense, more summary — which is worth knowing before
+treating it as a style sample.
 
-Quotes below are verbatim from the repo. This file exists so the voice lives in the repo rather
-than in any one tool's memory.
-
-**Reading coverage.** All 83 chapters have now been read in full (53–55 do not exist). Everything
-below is both measured and read.
+Two companion files sit alongside this one: `story-so-far.md` for plot and character arcs, and
+`to-do-list.md` for tracked fixes. This file exists so the voice lives in the repo rather than in
+any one tool's memory.
 
 ## The workflow that produced these
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 .sass-cache
 .jekyll-metadata
 Gemfile.lock
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# Dungeons & Flagons
+
+Session notes for an ongoing D&D campaign, published as a Jekyll site at
+<https://todhilton.com/dnd/>. Sessions run roughly every two weeks; each one becomes a chapter.
+
+The party: Bilwin (dwarf cleric/bard), Dolor Vagarpie (tiefling rogue), Grindlefoot (halfling
+druid), Gven Vetkam (half-orc barbarian), Mond Blue (half-elf sorcerer). World is Olam;
+the continent is Eritz.
+
+## Layout
+
+| Path | Contents |
+|---|---|
+| `_posts/` | Everything. 88 files: 81 chapters, 6 character posts, 1 appendix |
+| `_pages/` | `about.md` plus the archive pages (category/tag/year) and 404 |
+| `_data/navigation.yml` | Top nav |
+| `assets/images/` | Maps, handouts, screenshots |
+| `_config.yml` | Site config; theme is `mmistakes/minimal-mistakes` via `remote_theme` |
+
+There are no `_layouts` or `_includes` — everything comes from the remote theme.
+
+## Posts
+
+Filename is `YYYY-MM-DD-chapter-N.md`, where the date is the **session date**, not the writing
+date. Chapters are numbered sequentially and never renumbered.
+
+Three categories, and a post has exactly one:
+
+- `campaign` — chapters (81)
+- `adventurers` — one post per player character (6)
+- `notes` — the appendix (1)
+
+Front matter for a chapter:
+
+```yaml
+---
+title: "Chapter 83"
+show_date: true
+date: 2026-07-20T17:00:00-00:00
+sessiondate: "July 20, 2026"
+modified: 2026-07-20
+categories:
+  - campaign
+tags:
+  - eve-of-ruin
+  - fight
+  - mournland
+---
+```
+
+`title`, `show_date`, `date`, `categories`, and `tags` appear on all 88 posts. `sessiondate` is
+on the 82 session-derived ones. `modified` is set when a post is revised after publishing.
+
+Tags are lowercase-hyphenated and do real navigational work — the tag archive is a main nav item.
+They mix arc names (`eve-of-ruin`, `rod-of-seven-parts`), locations (`mournland`, `elsemar`,
+`wayside`), NPCs (`landro`), and event types (`fight`, `levelup`, `secret-learned`,
+`guest-player`). Reuse an existing tag rather than coining a near-duplicate; check
+`grep -h -A20 '^tags:' _posts/*.md | grep '^\s*-' | sort | uniq -c | sort -rn` first.
+
+## Writing chapters
+
+**Read `.claude/writing-voice.md` before drafting or editing any chapter prose.** It documents the
+voice in detail, derived from chapters 78–83 measured against the earlier corpus, with examples.
+
+The short version: narrative prose, third person, **present tense** ("Mond hangs from a rung of the
+ladder…"), past tense only for things that already happened. Recent chapters run 2,000–4,600 words.
+Characters go by first name. It reads as a story, not a bulleted session log — no "the party then
+decided to." Dice outcomes are narrated as events, never as numbers in the prose.
+
+`---` on its own line marks a scene break (used in about half the chapters — where the session had
+distinct scenes).
+
+Links to D&D Beyond for monsters, spells, and rules are common and welcome.
+
+### Session notes live in HTML comments
+
+83 of 88 posts carry `<!-- ... -->` blocks that don't render: initiative rolls, round-by-round
+fight choreography, `<!-- NOTES -->` scratch, and reference cheat-sheets the author keeps handy
+(em dash character, frequently-used links, ship direction glossary). **Preserve these when
+editing.** They're the raw material behind the prose — treat them as the author's working notes,
+not as cruft to clean up.
+
+### The Claude tag
+
+Chapters 79–83 carry the tag `co-written-with-claude`. **If you help write or substantially revise
+a chapter, add that tag.** It's how the author tracks provenance. (Distinct from `ai-generated` on
+`2025-09-01-chapter-62-ai.md`, a one-off fully-AI alternate version of chapter 62 published
+alongside the human-written one.)
+
+Note: chapter 78 was the first Claude-drafted chapter — its trailing comment says so — but it was
+never tagged. The drafted run is really 78–83.
+
+## Internal links — read this before writing any
+
+The site is served from a subpath, but `_config.yml` sets **no `baseurl`**. Every internal link is
+therefore written with a hardcoded `/dnd` prefix:
+
+```markdown
+[ch. 14](/dnd/campaign/chapter-14/)
+![Wayside's layout](/dnd/assets/images/town-wayside-layout.png)
+```
+
+Permalinks resolve as `/:categories/:title/`, so chapter 83 lives at `/dnd/campaign/chapter-83/`
+and a character at `/dnd/adventurers/bilwin/`.
+
+Some older links use the absolute form `https://todhilton.com/dnd/...` instead. Both work. Match
+the surrounding file; prefer the root-relative `/dnd/...` form in new writing.
+
+## Build and deploy
+
+```bash
+bundle install
+bundle exec jekyll serve   # http://localhost:4000/dnd/
+```
+
+Deploy is a push to `main` — GitHub Pages builds it. There is no CI and no build step to run
+before committing. Because the `github-pages` gem pins versions, a plugin that works locally may
+still be unavailable on Pages; stick to the plugins already listed in `_config.yml`.
+
+Note `jekyll-algolia` is in the `Gemfile` but not in `_config.yml`'s plugin list — search comes
+from the theme's built-in Lunr, not Algolia.

--- a/_config.yml
+++ b/_config.yml
@@ -34,16 +34,19 @@ include:
   - _pages
 
 # Exclude from processing.
-# The following items will not be processed, by default. Create a custom list
-# to override the default setting.
-# exclude:
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+# Setting this REPLACES Jekyll's defaults rather than adding to them, so the default
+# entries below must stay listed or files like the Gemfile start getting published.
+# Dotfiles and dot-directories (.claude/, .git/) are skipped by Jekyll automatically.
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - gemfiles
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - CLAUDE.md
 
 # Plugins (previously gems:)
 plugins:


### PR DESCRIPTION
Adds a set of project docs under `.claude/`, plus `CLAUDE.md` at the repo root, and keeps all of it out of the published site.

The docs are derived from **reading all 83 chapters in full**, plus the appendix — not from sampling or measurement alone.

## Files

| File | Contents |
|---|---|
| **`CLAUDE.md`** (root) | Repo layout, post and front-matter conventions, the tag vocabulary, the hardcoded `/dnd` link prefix, build/deploy notes |
| **`.claude/writing-voice.md`** | The narrative voice — registers, NPC craft, combat, structure, crutches, and what to suppress when drafting |
| **`.claude/story-so-far.md`** | Plot and character arcs for ch. 1–39, which the appendix doesn't cover (it indexes people and places, not what happened to whom) |
| **`.claude/to-do-list.md`** | Tracked suggestions — nothing acted on, checkboxes to tick in place |

## What the reading turned up

The voice guide went through several rounds of correction as coverage widened. The claims that changed:

**Corrected**

- **Epithets** ("the dwarf," "the half-orc") were described as rare. They aren't — 411 uses across ch. 56–77, 71 per 10k words, cut to 24 per 10k in the drafted chapters. Guidance reversed.
- **"A sharp break at ch. 78"** overstated it. Shorter sentences and paragraphs are a three-year trajectory, not a break. Only chapter length and dialogue actually reversed.
- **"Emotional beats were previously summarized"** was wrong. Chapters 63, 66, 67, 68, and 74 give them more room than anything in 78–83.
- **"One interior beat per chapter"** was wrong. The round-robin — every companion getting an interior beat in sequence — is the signature non-combat structure, established by ch. 42.
- **List-form combat** was recorded as an early experiment that ended by ch. 3. It ran the other way: rendered bulleted combat with damage numbers on the page was the *published* format for ~30 chapters. The `<!-- Step-by-step -->` blocks at ch. 38/39/43 are the transition back *out* of it. Prose still won, and those chapters are a rewrite backlog, not precedent.
- **"The narrator addresses the reader exactly once, in ch. 16."** Also in ch. 2, 5, 22, and 26, plus a narrator's ", mind you" in 20, 24, 34, and 74.
- **The `_The group has learned the secret_` marker** starts at ch. 56, not ch. 65.
- **The repeated map ending** is seven of eight chapters in ch. 45–52, not seven in a row — ch. 47 breaks it.
- **Bulleted lists** weren't fully abandoned; ch. 58 uses one for documents the characters are reading, which is the form worth keeping.
- **"The party decides to…"** was listed as a Don't. It appears ~25 times from ch. 3 to ch. 80, including in the drafted run — a habit to watch, not a foreign tic.

**Added**

- **The party in ch. 1–13 is a different party.** Bilwin and Mond don't exist yet; the fourth founder is Xantic, a gnome artificer, with a homunculus named McGillicutty. The roster turns over inside ch. 14, entirely through scene. "The Mixed Nuts" becomes "Chimera's Bane" in ch. 7.
- **Puzzle and set-piece chapters have two solution modes**, not one. As often as a character reasons a puzzle out, the party bypasses it with an ability or brute force — and the comedy comes from what the bypass costs.
- **Pun and parody are a whole comic register** the guide had no entry for (Food Alley, ch. 19–21). Dry understatement is the late mode, not the only one.
- **NPC voice** as the hardest thing to imitate, with a register table — now including Tham, Whelm, Cap'n Don, Cindel, Rightside, and Hanseath in person.
- **Dave Chevits is a disguise** — he's Fenseck, the efreeti who granted Dolor's warlock powers. The knitting halfling in ch. 47 is Dolor's patron inspecting his own warlock.
- **Gven is on her own *Coming Out* journey** while searching for Torp. Both siblings left the same tribe on the same rite; he came back a zealot. That makes the arc a comparison, not an errand.
- Chapter opening and ending patterns with frequencies, a measured crutch table, verse and marker conventions, profanity guidance, and origins for Gleaming Blade and Tempest Edge — including Gven's still-open debt to Veylara.

## Things found that need decisions

These are recorded in `to-do-list.md` and **not acted on**:

- **Chapters 53–55 were never written.** Not a numbering skip — three sessions that never got written up. The appendix documents their content and links to them, so seven appendix links are 404s, and ch. 56 opens with "The adventurers leave The Gilded Glyph," a shop the reader has never seen.
- **The appendix has the Eyes of the Star and Hand of the Wand descriptions swapped** relative to ch. 5, which is explicit that the Hands of the Wand track magic users and are magic users themselves. The names side with ch. 5 — wand, arcane. Load-bearing worldbuilding.
- **"Everwinter" should be "Evernight"** in the appendix (2 places); every chapter says Evernight.
- The appendix's **Davanor entry predates the ch. 28 reveal** that Davanor is Torp.
- **19 chapters still render turn-by-turn combat** and want converting to prose; ch. 13 is the biggest job.
- **Ch. 78 is missing the `co-written-with-claude` tag** — it was the first Claude-drafted chapter.

## Why the files live where they do

`CLAUDE.md` must stay at the repo root to be picked up automatically — moving it into a subdirectory silently disables it. Supporting docs have no such constraint, so they go in `.claude/`.

## Why `_config.yml` changes

Root-level files are published today. Verified against the live site:

```
https://todhilton.com/dnd/README.md  -> 200 text/markdown
https://todhilton.com/dnd/Gemfile    -> 404   (in Jekyll's default exclude)
```

Without this change, `CLAUDE.md` would serve at `/dnd/CLAUDE.md` once merged. Adding it to `exclude` prevents that.

The commented-out `exclude:` block is now active. **Setting `exclude` replaces Jekyll's defaults rather than extending them**, so the default entries are listed explicitly — otherwise enabling it would start publishing the `Gemfile`. `.claude/` needs no entry; Jekyll skips dot-directories automatically.

Config re-parsed after editing; `include`, `title`, and `remote_theme` are unchanged.

## Also

`.gitignore` gains `.claude/settings.local.json`, so a session run from inside this repo doesn't commit machine-local permissions.
