### PR TITLE
Add characters.md — appearance and demeanor for the party

### DIFF
--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -12,9 +12,10 @@ so below.
 Companion files: `writing-voice.md` for how to write them, `story-so-far.md` for what happened to
 them, `to-do-list.md` for tracked fixes.
 
-> **Room to grow:** magical weapons and gear are only partly recorded here — Gven's are complete
-> because the source doc lists them. Bilwin's Whelm and Sunburst Shield, Dolor's Gleaming Blade and
-> pocket watch, and Grindlefoot's silvered staff live in `story-so-far.md` and the appendix for now.
+> **Gear** is recorded in two places: each character's own entry for what they carry day to day, and
+> **Gear bought off-page — chapter 55** at the bottom, which is the full list from the Neverwinter
+> shopping trip that was never written. Items acquired on-page (Whelm, Gleaming Blade, the Sunburst
+> Shield, Dolor's pocket watch) are described in `story-so-far.md` and the appendix.
 
 ---
 
@@ -131,13 +132,11 @@ for harming. He has it silvered and carved with plant filigree in ch. 63.
 | Wooden Gruumsh amulet | before ch. 1 | Carved by her father. **Given to Veylara in ch. 32** — she no longer wears it |
 | Plain greatsword | before ch. 1 | Nondescript, non-magical, ~5 feet, scabbard across her back |
 | **Tempest Edge** | ch. 32 | Veylara's gift. Lightning once/day as a bonus action; lightning resistance; on a crit, a deafening thunderclap |
-| **Vestment of the Bound Sigil** | **ch. 55** | Sleeveless longcoat, arcane glyphs woven beneath the surface. +2 AC over light armour; once/day the sigils flare to absorb 10 damage |
+| **Vestment of the Bound Sigil** | **ch. 55** | See below |
+| **Boots of Striding and Springing** | ch. 63 | Bought on-page from a gnome cordwainer |
 
-The longcoat is bought at the Gilded Glyph in Neverwinter in **chapter 55 — one of the unwritten
-sessions**, which is why it appears in the prose from ch. 59 onward with no introduction. It's the
-"shimmering longcoat" and "enchanted coat" the later chapters keep referring to.
-
-Note the scabbard moves: across her back early, at her hip by ch. 77.
+The longcoat is the "shimmering longcoat" and "enchanted coat" the later chapters keep referring to
+from ch. 59 onward. Note the scabbard moves: across her back early, at her hip by ch. 77.
 
 ## Mond Blue
 
@@ -168,6 +167,47 @@ The source entry is unfinished: **hair, clothing, and weapons are blank.** If he
 those are open to invention. He leaves the party in ch. 14 to stay in Wayside.
 
 ---
+
+## Gear bought off-page — chapter 55
+
+**This is the single biggest continuity trap in the campaign.** Alustriel transported the party to
+Neverwinter, where magic and religion are openly legal and there are actual magic shops — the first
+time they've had access to any. They spent heavily. **Chapter 55 was never written**, so *none* of
+this has an on-page acquisition scene, and items simply start appearing in later chapters as though
+the reader saw them bought.
+
+Session date May 12, 2025. Source: Tod's `MagicItems-Level9-Neverwinter` doc.
+
+| Character | Item | Cost | Effect | On the page? |
+|---|---|---|---|---|
+| **Gven** | **Vestment of the Bound Sigil** | 4,500 gp | +2 AC even over light armour or robes; once/day the sigils flare to absorb 10 damage from one attack | ✅ ch. 59 on |
+| **Bilwin** | **Battle axe** | 750 gp | +1 to attack and damage | ✅ ch. 56 on |
+| **Bilwin** | **Bag of Holding** | 1,250 gp | A fancy-looking bag | ✅ ch. 57, 58 |
+| **Bilwin** | **Ironbound Wardchain** | 2,000 gp | AC 16. Once/long rest, when reduced to 0 HP, drop to 1 instead — the links pulse dull blue when it fires | ⚠️ unnamed |
+| **Mond** | **Bag of Holding** | 1,000 gp | Scorched inside, hence discounted. Auto-transfers items in possession; retrieve by name | ✅ ch. 57 |
+| **Mond** | **Draconic Sigil Tattoo** | 2,000 gp | Glowing abstract dragon. Once/long rest cast *shield*. Once/long rest, damage that would drop him to 0 instead leaves him at 1 and bursts into draconic flame — 2d10 to enemies within 10 ft | ❌ never |
+| **Dolor** | **Signet Ring of Wyrmkind Favor** | 4,000 gp | Insignia of an ancient noble dragon. +2 Charisma (max 22); advantage on Intimidation and Persuasion against creatures of Int 6+ | ❌ never |
+| **Grindlefoot** | **Collar of Breath and Blood** | 4,500 gp | Red crystal set in bronze, warm to the touch. +1 Constitution; once/long rest *Enhance Ability (Bear's Endurance)* free; advantage on Concentration checks | ❌ never |
+| **Grindlefoot** | **Seed Pouch of Old Barrows** | 500 gp | 3d6 magical seeds. Planted and watered — or *Druidcraft* cast nearby — they grow overnight into thick bushes (half cover), healing herbs (*Cure Wounds* 1d8+3, one use), or strange hybrid fruit with random effects. **Refills every new moon** | ❌ never |
+
+**Three things worth acting on:**
+
+- **Four items have never appeared in the prose at all.** Mond's tattoo, Dolor's ring, and both of
+  Grindlefoot's. They're owned and paid for; they simply haven't been written.
+- **Grindlefoot's collar was specifically re-specced.** It was going to be an amulet, and he asked
+  for a collar *so it would still be on him when he transforms*. That's a visual that should be
+  showing up every time he wild shapes into a spider or a dire wolf, and never has. (Don't confuse
+  it with Ikasa's talking collar in ch. 71.)
+- **The Seed Pouch is an unused story device**, and a very Grindlefoot one — a bag that grows cover,
+  healing, or a surprise overnight, and refills on the new moon.
+
+Bilwin's **Ironbound Wardchain** is the ⚠️: it's almost certainly the "dwarf's chainmail" that gets
+slashed in ch. 66 and broken through in ch. 73, but it's never named and its once-a-day
+save-from-zero has never visibly fired.
+
+**The other shopping trip, ch. 63, *is* written**, so those items have proper introductions: Dolor's
+studded leather sewn with lucky copper pieces, Gven's Boots of Striding and Springing, Grindlefoot's
+staff silvered and carved with plant filigree, and Bilwin's Sunburst Shield.
 
 ## Source notes
 

--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -1,0 +1,174 @@
+# Characters
+
+Physical descriptions and demeanor for the five player characters, plus Xantic. Use this when
+writing anything that describes what someone looks like, wears, carries, or how they carry
+themselves.
+
+**Source:** the "Characters" section of *D&D Book 1 — proposal & outline*
+([Google Doc](https://docs.google.com/document/d/1SfqiQzS9lZKa2k7G9hgkHG0S2DFLctDo1T01YmUPbJA/edit)),
+written to brief a cover artist. Cross-checked against the chapters; where the two disagree it says
+so below.
+
+Companion files: `writing-voice.md` for how to write them, `story-so-far.md` for what happened to
+them, `to-do-list.md` for tracked fixes.
+
+> **Room to grow:** magical weapons and gear are only partly recorded here — Gven's are complete
+> because the source doc lists them. Bilwin's Whelm and Sunburst Shield, Dolor's Gleaming Blade and
+> pocket watch, and Grindlefoot's silvered staff live in `story-so-far.md` and the appendix for now.
+
+---
+
+## At a glance
+
+| | Species | Class | Height | Age | Looks about |
+|---|---|---|---|---|---|
+| **Bilwin** | Dwarf | Cleric & Bard | 4′1″ | 30 | 40 human |
+| **Dolor Vagarpie** | Tiefling | Rogue *(see note)* | 5′2″ | 30 | 30 human |
+| **Grindlefoot** | Halfling | Druid | 3′1½″ | 30 | 25–30 human |
+| **Gven Vetkam** | Half-orc | Barbarian | 6′8″ | 23 | 23 human |
+| **Mond Blue** | Half-elf | Sorcerer | 5′10″ | 31 | 31 human |
+| **Xantic Gearslip** | Rock gnome | Artificer | 3′4″ | 35 | 35 human |
+
+Gven is the tallest by more than half a foot and the youngest by seven years. Grindlefoot is the
+smallest. Bilwin is shorter than Xantic.
+
+---
+
+## Bilwin the Magnificent
+
+**Dwarf · Cleric & Bard · male · 30**
+
+- **Hair** medium-dark, to the shoulders. **Eyes** brown. **Ears** round.
+- **Face** moderate bone structure and size.
+- **Complexion** light. **Height** 4′1″.
+- **Build** lean — not skinny, but unusually lean for a dwarf, who are normally short and stocky.
+- **Clothing** dresses how he imagines a great bard dresses: a fuchsia flowy shirt under leather
+  armor, shiny boots, painted fingernails.
+- **Instrument** a hurdy-gurdy carried in a studded leather case on his back.
+- **Weapon** the hurdy-gurdy, still in its case.
+- **Demeanor** loud, very talkative, obnoxious. Speaks without thinking about consequences. Loves
+  beer, both brewing and drinking it.
+
+**The beard is a clock.** When he joins in ch. 14 he has **only a mustache**, no beard — which is
+not the dwarven norm and is a deliberate character choice. He lets it grow over the campaign, and by
+the Rod of Seven Parts era (ch. 64 on) it's full and reaches past his neck to nearly his chest —
+still not down to the belt like a proper dwarf's. Ch. 67 confirms it: in the bath, his belly-length
+beard floats just under the water. **Check where you are in the timeline before describing it.**
+
+## Dolor Vagarpie
+
+**Tiefling · male · 30**
+
+- **Hair** dark, to the middle of his back. **Eyes** dark, possibly black. **Ears** pointed.
+- **Horns** long, running from his forehead back beyond his head.
+- **Tail** 4–5 feet long, 6–8 inches in diameter at the base.
+- **Face** moderate bone structure and size, no facial hair.
+- **Complexion** the source doc says **bluish** — but every chapter that describes him says
+  **purple**, and ch. 76 is specific: *"a deeper shade of purple, almost lavender in its coolness."*
+  The chapters win; ch. 76 sets it against Mercy's vibrant purple plating deliberately.
+- **Height** 5′2″. **Build** muscular and stocky.
+- **Clothing** nondescript travel clothes and a leather jacket. **Likes the colour purple.** Wears a
+  **pendant made by his parents** — a blown-glass diamond on an intricate silver chain.
+- **Weapons** (as briefed) bow and arrow, plain daggers.
+- **Demeanor** solemn, respectful, high moral standards, always wants to do the right thing.
+
+**Class note.** The doc lists him as a straight Rogue, which was true for the era it covers. He has
+since multiclassed: fighter abilities by ch. 38 (Action Surge, Second Wind) and **warlock** from
+ch. 47, when Fenseck grants him the pact. See `story-so-far.md`.
+
+**The pendant matters.** His parents were jewelers and glassblowers, and the parents thread is the
+campaign's live mystery — he builds a glory hole in Neverwinter in ch. 63 and finds their work again
+in ch. 74 and 82.
+
+## Grindlefoot
+
+**Halfling · Druid · male · 30 (looks ~25)**
+
+- **Hair** blond, below the ears and above the shoulder. **Eyes** blue.
+- **Ears** very slightly pointed — could read as round at a glance.
+- **Face** round, with a beard kept at about an inch.
+- **Complexion** light. **Height** 3′1½″. **Build** moderate.
+- **Clothing** overalls, cloth shirt, **no shoes**, and a **bowler hat**.
+- **Weapon** a garden hoe with the metal head removed, used as a staff.
+- **Demeanor** happy-go-lucky, curious, soft-spoken, makes impromptu decisions quickly.
+
+The bowler hat survives wild shape — ch. 79 has it perched on a fifteen-foot wolf spider "tilted at
+a determined angle," and he catches it each time it tumbles free. The staff was literally his farm
+tool; ch. 44 gives him a quiet moment on how strange it is that a thing for growing became a thing
+for harming. He has it silvered and carved with plant filigree in ch. 63.
+
+## Gven Vetkam
+
+**Half-orc (half-human) · Barbarian · female · 23**
+
+- **Hair** dark brown, long enough for a single braid falling just below the shoulder blades.
+- **Eyes** hazel. **Ears** pointed.
+- **Face** chiseled, **freckles under the eyes**, **one dimple**, and **small tusks** protruding up
+  from the lower jaw — smaller than a full orc's, but noticeable.
+- **Complexion** light-to-medium. **Height** 6′8″.
+- **Build** muscular and athletic, on the leaner side rather than heavy-set.
+- **Clothing** mismatched leather travel clothes in browns; her only armour is a **single leather
+  pauldron on one shoulder**.
+- **Demeanor** exudes confidence and has the muscle to back it. Doesn't talk much. Speaks directly
+  and to the point. Lets most things roll off her back, but will get into it if pushed.
+
+**Gear, in timeline order:**
+
+| Item | Acquired | Notes |
+|---|---|---|
+| Wooden Gruumsh amulet | before ch. 1 | Carved by her father. **Given to Veylara in ch. 32** — she no longer wears it |
+| Plain greatsword | before ch. 1 | Nondescript, non-magical, ~5 feet, scabbard across her back |
+| **Tempest Edge** | ch. 32 | Veylara's gift. Lightning once/day as a bonus action; lightning resistance; on a crit, a deafening thunderclap |
+| **Vestment of the Bound Sigil** | **ch. 55** | Sleeveless longcoat, arcane glyphs woven beneath the surface. +2 AC over light armour; once/day the sigils flare to absorb 10 damage |
+
+The longcoat is bought at the Gilded Glyph in Neverwinter in **chapter 55 — one of the unwritten
+sessions**, which is why it appears in the prose from ch. 59 onward with no introduction. It's the
+"shimmering longcoat" and "enchanted coat" the later chapters keep referring to.
+
+Note the scabbard moves: across her back early, at her hip by ch. 77.
+
+## Mond Blue
+
+**Half-elf (half-human) · Sorcerer · male · 31**
+
+- **Hair** dark brown, just above the shoulders. **Eyes** dark brown. **Ears** pointed.
+- **Face** lengthy, thin and angular, no facial hair.
+- **Complexion** darker — brown. **Height** 5′10″. **Build** slight and thin.
+- **Clothing** nondescript travel clothes in earth tones — pants, shirt, light jacket, boots.
+- **Weapon** a light crossbow he keeps hidden where possible, under his jacket or in his pack.
+- **Demeanor** logical-minded. Tries not to be noticed, keeps to the shadows, and **doesn't talk
+  much because he doesn't want to be recognised as a magic user.**
+
+That last clause is the whole character. The reticence is not shyness, it is self-protection in a
+country that outlaws what he is — which is exactly why the Neverwinter chapters land so hard for
+him. See his thread in `story-so-far.md`.
+
+## Xantic Gearslip
+
+**Rock gnome · Artificer · male · 35 — party member ch. 1–14 only**
+
+- **Eyes** brown. **Ears** pointed. **Face** round, thin beard.
+- **Complexion** light-to-medium. **Height** 3′4″. **Build** medium-to-heavy.
+- **Demeanor** logical-minded, boisterous, talkative, curious, engages with everyone. Always
+  tinkering and building things — an engineer's mindset.
+
+The source entry is unfinished: **hair, clothing, and weapons are blank.** If he needs describing,
+those are open to invention. He leaves the party in ch. 14 to stay in Wayside.
+
+---
+
+## Source notes
+
+The document is a **book proposal**, not a character bible — Tod's plan to publish chapters 1–28 as
+a self-published book, with the character descriptions written to brief a cover artist. Two things
+worth knowing from it:
+
+- **Attribution:** authors Tod & Dave S.; creative team Dave H., Doug, Liam, Sanjaya & Eric. Dave
+  Shevitz is the DM. This is where ch. 26's `Originally written by Liam and edited by Tod` comes
+  from — Liam is on the creative team.
+- **"Rewrite battles from lists into prose"** is listed there as in-progress work, which is the same
+  backlog tracked in `to-do-list.md`.
+
+Because it covers chapters 1–28, some entries are frozen at that point in the campaign — Dolor's
+class is the clearest case. Prefer the chapters where they conflict, and prefer this doc for
+physical description, which the chapters rarely give in full.

--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -63,18 +63,28 @@ beard floats just under the water. **Check where you are in the timeline before 
 - **Horns** long, running from his forehead back beyond his head.
 - **Tail** 4–5 feet long, 6–8 inches in diameter at the base.
 - **Face** moderate bone structure and size, no facial hair.
-- **Complexion** the source doc says **bluish** — but every chapter that describes him says
-  **purple**, and ch. 76 is specific: *"a deeper shade of purple, almost lavender in its coolness."*
-  The chapters win; ch. 76 sets it against Mercy's vibrant purple plating deliberately.
+- **Complexion** purple. Ch. 76 is the most specific: *"a deeper shade of purple, almost lavender in
+  its coolness"* — set deliberately against Mercy's vibrant purple plating in the same paragraph.
 - **Height** 5′2″. **Build** muscular and stocky.
 - **Clothing** nondescript travel clothes and a leather jacket. **Likes the colour purple.** Wears a
   **pendant made by his parents** — a blown-glass diamond on an intricate silver chain.
 - **Weapons** (as briefed) bow and arrow, plain daggers.
 - **Demeanor** solemn, respectful, high moral standards, always wants to do the right thing.
 
-**Class note.** The doc lists him as a straight Rogue, which was true for the era it covers. He has
-since multiclassed: fighter abilities by ch. 38 (Action Surge, Second Wind) and **warlock** from
-ch. 47, when Fenseck grants him the pact. See `story-so-far.md`.
+**Class note.** The source doc lists him as a straight Rogue, which was true for the chapters it
+covers. He has since multiclassed: fighter abilities by ch. 38 (Action Surge, Second Wind) and
+**warlock** from the Amonah temple.
+
+On the warlock pact specifically, since it's easy to cite wrong: **ch. 47 is the reveal, not the
+event.** Dave Chevits drops the disguise on his way out — *"Call for Fenseck when you next need
+me"* — and Dolor recognises the efreeti he made the pact with. But he is already casting Eldritch
+Blast in **ch. 46**, at the ziggurat's glass wall. Ch. 67 and 68 both place the pact vaguely "in the
+temple on Amonah" (ch. 45–52); it is never shown on the page. Ch. 67 gives the motive: he'd wanted
+to be a rogue since childhood and found he wasn't good enough at it — arrows going wide, ropes
+defeating him — and Fenseck offered an alternative.
+
+(Ch. 27 also contains Eldritch Blasts, but they're cast *at* Dolor by enemy clerics. His Hellish
+Rebuke from ch. 6 on is a tiefling racial trait, not warlock.)
 
 **The pendant matters.** His parents were jewelers and glassblowers, and the parents thread is the
 campaign's live mystery — he builds a glory hole in Neverwinter in ch. 63 and finds their work again
@@ -169,6 +179,10 @@ worth knowing from it:
 - **"Rewrite battles from lists into prose"** is listed there as in-progress work, which is the same
   backlog tracked in `to-do-list.md`.
 
-Because it covers chapters 1–28, some entries are frozen at that point in the campaign — Dolor's
-class is the clearest case. Prefer the chapters where they conflict, and prefer this doc for
-physical description, which the chapters rarely give in full.
+Because it covers chapters 1–28, some entries are frozen at that point in the campaign — **Dolor's
+class is the clearest case**, listed as a straight Rogue, which predates his fighter abilities and
+the warlock pact. Prefer the chapters where the two disagree, and prefer this doc for physical
+description, which the chapters rarely give in full.
+
+*(The doc originally gave Dolor's complexion as bluish, which conflicted with every chapter that
+describes him. Tod corrected it to purple at the source, so the two now agree.)*

--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -23,7 +23,7 @@ them, `to-do-list.md` for tracked fixes.
 | | Species | Class | Height | Age | Looks about |
 |---|---|---|---|---|---|
 | **Bilwin** | Dwarf | Cleric & Bard | 4′1″ | 30 | 40 human |
-| **Dolor Vagarpie** | Tiefling | Rogue *(see note)* | 5′2″ | 30 | 30 human |
+| **Dolor Vagarpie** | Tiefling | Rogue & Warlock | 5′2″ | 30 | 30 human |
 | **Grindlefoot** | Halfling | Druid | 3′1½″ | 30 | 25–30 human |
 | **Gven Vetkam** | Half-orc | Barbarian | 6′8″ | 23 | 23 human |
 | **Mond Blue** | Half-elf | Sorcerer | 5′10″ | 31 | 31 human |
@@ -57,7 +57,7 @@ beard floats just under the water. **Check where you are in the timeline before 
 
 ## Dolor Vagarpie
 
-**Tiefling · male · 30**
+**Tiefling · Rogue & Warlock · male · 30**
 
 - **Hair** dark, to the middle of his back. **Eyes** dark, possibly black. **Ears** pointed.
 - **Horns** long, running from his forehead back beyond his head.
@@ -71,11 +71,7 @@ beard floats just under the water. **Check where you are in the timeline before 
 - **Weapons** (as briefed) bow and arrow, plain daggers.
 - **Demeanor** solemn, respectful, high moral standards, always wants to do the right thing.
 
-**Class note.** The source doc lists him as a straight Rogue, which was true for the chapters it
-covers. He has since multiclassed: fighter abilities by ch. 38 (Action Surge, Second Wind) and
-**warlock** from the Amonah temple.
-
-On the warlock pact specifically, since it's easy to cite wrong: **ch. 47 is the reveal, not the
+**When the warlock half started**, since it's easy to cite wrong: **ch. 47 is the reveal, not the
 event.** Dave Chevits drops the disguise on his way out — *"Call for Fenseck when you next need
 me"* — and Dolor recognises the efreeti he made the pact with. But he is already casting Eldritch
 Blast in **ch. 46**, at the ziggurat's glass wall. Ch. 67 and 68 both place the pact vaguely "in the
@@ -85,6 +81,12 @@ defeating him — and Fenseck offered an alternative.
 
 (Ch. 27 also contains Eldritch Blasts, but they're cast *at* Dolor by enemy clerics. His Hellish
 Rebuke from ch. 6 on is a tiefling racial trait, not warlock.)
+
+**Open question — fighter features.** Three times *before* the pact, Dolor uses abilities the
+chapters explicitly link to the **Fighter** class: `Second Wind` in ch. 36 and `action surge` twice
+in ch. 38, both linked to fighter class pages. That doesn't fit Rogue & Warlock. It could be an
+early multiclass that was later rebuilt, or the wrong link picked while drafting. **Tod or Doug
+would know; nothing has been assumed here.**
 
 **The pendant matters.** His parents were jewelers and glassblowers, and the parents thread is the
 campaign's live mystery — he builds a glory hole in Neverwinter in ch. 63 and finds their work again
@@ -179,10 +181,12 @@ worth knowing from it:
 - **"Rewrite battles from lists into prose"** is listed there as in-progress work, which is the same
   backlog tracked in `to-do-list.md`.
 
-Because it covers chapters 1–28, some entries are frozen at that point in the campaign — **Dolor's
-class is the clearest case**, listed as a straight Rogue, which predates his fighter abilities and
-the warlock pact. Prefer the chapters where the two disagree, and prefer this doc for physical
-description, which the chapters rarely give in full.
+Because it covers chapters 1–28, some entries could go stale as the campaign moves on — a class
+gained late, a piece of gear traded away. **As of now the doc and the chapters agree on everything
+here**, so treat the doc as authoritative for physical description, which the chapters rarely give
+in full, and the chapters as authoritative for anything that changed after ch. 28.
 
-*(The doc originally gave Dolor's complexion as bluish, which conflicted with every chapter that
-describes him. Tod corrected it to purple at the source, so the two now agree.)*
+*(Two entries were out of date when this file was first written and Tod corrected them at the
+source: Dolor's complexion, which said bluish where every chapter says purple, and his class, now
+Rogue & Warlock. The only thing still unreconciled is the fighter-feature question noted in his
+entry above.)*

--- a/.claude/to-do-list.md
+++ b/.claude/to-do-list.md
@@ -57,6 +57,22 @@ Alustriel Silverhand.
 
 - [ ] Decide: write them, or renumber, or leave them as a gap and fix the links to point elsewhere
 
+**Ch. 55 was the party's first-ever magic shopping trip** and its consequences are already loose in
+the prose. Full item list is in `characters.md` under "Gear bought off-page." Four items were bought
+and paid for but have **never once appeared in a chapter**:
+
+- [ ] **Mond — Draconic Sigil Tattoo** (2,000 gp). Free *shield* once/long rest, and a
+      drop-to-1-HP-and-explode effect that has never fired on the page
+- [ ] **Dolor — Signet Ring of Wyrmkind Favor** (4,000 gp). +2 Cha and advantage on Intimidation and
+      Persuasion. He does a lot of talking to NPCs; this has never been visible in any of it
+- [ ] **Grindlefoot — Collar of Breath and Blood** (4,500 gp). Deliberately re-specced from an amulet
+      to a **collar so it stays on when he wild shapes** — a visual that should appear every
+      transformation and never has
+- [ ] **Grindlefoot — Seed Pouch of Old Barrows** (500 gp). Grows cover, healing herbs, or odd fruit
+      overnight; refills each new moon. An unused story device, and a very Grindlefoot one
+- [ ] **Bilwin — Ironbound Wardchain** (2,000 gp) is probably the "dwarf's chainmail" in ch. 66 and
+      73, but is never named, and its once-a-day save-from-zero has never visibly triggered
+
 ---
 
 ## 3. Appendix corrections

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -10,9 +10,9 @@ session notes preserved below it. It is the only chapter in 1–77 with another 
 and it reads slightly differently — more past tense, more summary — which is worth knowing before
 treating it as a style sample.
 
-Two companion files sit alongside this one: `story-so-far.md` for plot and character arcs, and
-`to-do-list.md` for tracked fixes. This file exists so the voice lives in the repo rather than in
-any one tool's memory.
+Three companion files sit alongside this one: `story-so-far.md` for plot and character arcs,
+`characters.md` for what the party look like and how they carry themselves, and `to-do-list.md` for
+tracked fixes. This file exists so the voice lives in the repo rather than in any one tool's memory.
 
 ## The workflow that produced these
 
@@ -184,6 +184,10 @@ characters talk — to each other, to NPCs, to corpses. Scenes advance through w
 See the "Yours vs. Claude's" section below: this is the single biggest thing to protect.
 
 ## Characters
+
+This section is about how they *behave*. For what they look like, wear, and carry — heights, hair,
+Gven's tusks and single pauldron, Grindlefoot's bowler hat and bare feet, the state of Bilwin's
+beard at a given point in the campaign — see **`characters.md`**.
 
 Comedy and competence both come from character, never from the narrator:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,10 @@ They mix arc names (`eve-of-ruin`, `rod-of-seven-parts`), locations (`mournland`
 ## Writing chapters
 
 **Read `.claude/writing-voice.md` before drafting or editing any chapter prose.** It documents the
-voice in detail, derived from chapters 78–83 measured against the earlier corpus, with examples.
+voice in detail, derived from a full read of all 83 chapters, with examples. Alongside it:
+`.claude/characters.md` (what the party look like and how they carry themselves),
+`.claude/story-so-far.md` (arcs, character threads, what's still unresolved), and
+`.claude/to-do-list.md` (tracked fixes).
 
 The short version: narrative prose, third person, **present tense** ("Mond hangs from a rung of the
 ladder…"), past tense only for things that already happened. Recent chapters run 2,000–4,600 words.


### PR DESCRIPTION
Adds `.claude/characters.md`, a fourth reference doc alongside the voice guide, story-so-far, and to-do list.

Two sources: the **Characters** section of the *D&D Book 1 — proposal & outline* Google Doc (written to brief a cover artist), and Tod's `MagicItems-Level9-Neverwinter` list. Cross-checked against the chapters throughout.

Nothing here touches the published site — `.claude/` is excluded in `_config.yml`.

## What it covers

All five PCs plus Xantic: species, class, height, age, hair, eyes, ears, face, complexion, build, clothing, carried weapons, and demeanor — with an at-a-glance table up front. (Gven is the tallest by more than half a foot and the youngest by seven years; Bilwin is shorter than Xantic.)

## The timeline-sensitive details

These are the reason the file exists — each one is a continuity error waiting to happen:

- **Bilwin's beard is a clock.** He joins in ch. 14 with **only a mustache** — deliberately not the dwarven norm — and grows it across the campaign, reaching past his neck to nearly mid-chest by the Rod of Seven Parts era. Ch. 67 confirms it floating in the bath.
- **Chapter 55 was the party's first-ever magic shopping trip, and it was never written.** Nine items entered play with no acquisition scene. The full list is in the file with cost and effect, cross-referenced against every chapter:

| | Items |
|---|---|
| ✅ On the page | Gven's Vestment of the Bound Sigil, Bilwin's battle axe + Bag of Holding, Mond's Bag of Holding |
| ⚠️ Present but unnamed | Bilwin's **Ironbound Wardchain** — almost certainly the "dwarf's chainmail" of ch. 66 and 73, but never named, and its once-a-day save-from-zero has never visibly fired. *This one is inference, not evidence.* |
| ❌ Never appeared at all | Mond's **Draconic Sigil Tattoo**, Dolor's **Signet Ring of Wyrmkind Favor**, Grindlefoot's **Collar of Breath and Blood** and **Seed Pouch of Old Barrows** |

Four items and 11,000 gp, invisible for thirty chapters. Two stand out: **the collar was re-specced from an amulet to a collar specifically so it stays on through wild shape**, which should be visible every transformation and never has; and **the Seed Pouch** — grows cover, healing herbs, or strange fruit overnight, refills each new moon — is an unused story device and about as Grindlefoot as an item gets. All four are now tracked in `to-do-list.md`.

The other shopping trip, **ch. 63, *is* written**, so those items have proper introductions.

## Doc vs. chapters

Writing this turned up two stale entries in the source, since it covers chapters 1–28. **Tod corrected both at the source**, so the two now agree throughout:

- Dolor's complexion said **bluish**; every chapter says purple (ch. 76: *"a deeper shade of purple, almost lavender in its coolness"*).
- Dolor's class said **Rogue**; it's now **Rogue & Warlock**.

**Xantic's entry is unfinished in the source** — hair, clothing, and weapons are blank — and the file says so rather than inventing them.

## Two things pinned down for future reference

- **The warlock pact.** Ch. 47 is the *reveal*, not the event — Dave Chevits drops the disguise on his way out, but Dolor is already casting Eldritch Blast in **ch. 46**. Chapters 67 and 68 place the pact only as "in the temple on Amonah" (ch. 45–52); it's never shown on the page. Ch. 27's Eldritch Blasts are enemy clerics casting *at* him, and Hellish Rebuke is a tiefling racial trait.
- **An open question:** three times before the pact, Dolor uses abilities the chapters link explicitly to the **Fighter** class — `Second Wind` in ch. 36, `action surge` twice in ch. 38. That fits neither Rogue nor Warlock. Could be an early multiclass since rebuilt, or the wrong link grabbed while drafting. Recorded as a question for Tod or Doug; nothing assumed.

## Also

Cross-linked from `writing-voice.md` (whose Characters section is about behaviour and now points here for appearance) and from `CLAUDE.md`, so the file gets found automatically.

While in `CLAUDE.md` I also corrected the writing-voice description, which still said the guide was "derived from chapters 78–83 measured against the earlier corpus" — it's a full read of all 83 now.