### PR TITLE
20260803-chapter-84

### DIFF
--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -83,15 +83,41 @@ defeating him — and Fenseck offered an alternative.
 (Ch. 27 also contains Eldritch Blasts, but they're cast *at* Dolor by enemy clerics. His Hellish
 Rebuke from ch. 6 on is a tiefling racial trait, not warlock.)
 
-**Open question — fighter features.** Three times *before* the pact, Dolor uses abilities the
+**The fighter features — answered.** Three times *before* the pact, Dolor uses abilities the
 chapters explicitly link to the **Fighter** class: `Second Wind` in ch. 36 and `action surge` twice
-in ch. 38, both linked to fighter class pages. That doesn't fit Rogue & Warlock. It could be an
-early multiclass that was later rebuilt, or the wrong link picked while drafting. **Tod or Doug
-would know; nothing has been assumed here.**
+in ch. 38. This was previously an open question here. It is not: the answer is in a comment block
+in his own character post, `_posts/2023-01-22-dolor-vagarpie.md`, where Doug explains the respec.
+
+He was rebuilt from pure rogue to **Rogue 5 / Warlock 3**, in November 2024. The patron is a
+**genie** (which is what Fenseck is), and the pact is **Pact of the Blade — Gleaming Blade is the
+pact weapon**. The fighter levels were traded away *in the fiction*, not retconned:
+
+> when he reached out to the Genie to enter into the warlock pact, he was given the option to
+> abandon the recent training in the martial world in exchange for gaining power in the arcane
+> world, he embraced that bargain
+
+Doug's reasoning is worth knowing because it reframes the character: the family "have hidden from
+their legacy because of the magic that is innate to them, this is a huge part of why he is so bent
+on addressing wrongs that he sees, he has spent his life feeling like he needs to hide who he truly
+is." The glass-blowing was always the tell — "his artistry and glass blowing has always leaned on
+this without his conscious awareness."
 
 **The pendant matters.** His parents were jewelers and glassblowers, and the parents thread is the
 campaign's live mystery — he builds a glory hole in Neverwinter in ch. 63 and finds their work again
 in ch. 74 and 82.
+
+**His family have names, and none of them have been spoken in a chapter.** From the backstory in
+his character post: his parents are **Amar** and **Alegría**, jewelers and watchmakers who roamed
+Eritz along the Ha-derech between Mirganor and Elsemar, "never charging more than they thought
+their clients could afford." He has a **sister, Lucha**, a painter — Dolor turned sand into glass,
+she painted.
+
+**Reveal status, stated precisely:** the names are *published* — the character post is live at
+`/dnd/adventurers/dolor-vagarpie/`, so a reader who goes looking has them. They have **never
+appeared in any of the 81 chapters**, including the entire Landro arc (ch. 75–84), which is built
+end to end on his parents having helped construct the colossus. When Dolor hears their voices in
+the gray fluid in ch. 81, the prose says "his parents." It does not name them. **That reveal is
+still available.**
 
 ## Grindlefoot
 
@@ -147,12 +173,25 @@ from ch. 59 onward. Note the scabbard moves: across her back early, at her hip b
 - **Complexion** darker — brown. **Height** 5′10″. **Build** slight and thin.
 - **Clothing** nondescript travel clothes in earth tones — pants, shirt, light jacket, boots.
 - **Weapon** a light crossbow he keeps hidden where possible, under his jacket or in his pack.
+- **Staff** a wooden staff. **Origin unrecorded** — it is not in the source doc and no chapter
+  shows him acquiring it; Tod confirms he carries one but doesn't recall when he got it. From
+  ch. 84 it carries **Landro's crystal** seated in its head, with the wood grown closed around it
+  by Grindlefoot's *Druidcraft*.
 - **Demeanor** logical-minded. Tries not to be noticed, keeps to the shadows, and **doesn't talk
   much because he doesn't want to be recognised as a magic user.**
 
 That last clause is the whole character. The reticence is not shyness, it is self-protection in a
 country that outlaws what he is — which is exactly why the Neverwinter chapters land so hard for
 him. See his thread in `story-so-far.md`.
+
+**His height disagrees across sources**: 5′10″ here (from the book-proposal doc), 5′9″ in his own
+character post `_posts/2023-01-22-mond-blue.md`. Unreconciled.
+
+**Where his character went after Elsemar** is recorded in a comment block in that same post, from
+Sanjaya and Dave: he hid his magic until hiding stopped being worth it, and now "fully embraces
+his nature." Dave's summary — *"he'd had enough bigotry for a lifetime and was done putting up
+with that shit."* Worth knowing before writing him as merely reticent; by the Rod era he has no
+patience left for zealots.
 
 ## Xantic Gearslip
 

--- a/.claude/story-so-far.md
+++ b/.claude/story-so-far.md
@@ -344,7 +344,12 @@ reason: Dolor had wanted to be a rogue since childhood and found he wasn't good 
 arrows went wide, ropes defeated him. Fenseck offered an alternative and he took it.
 
 **The parents thread is the campaign's live mystery and it is entirely his.** His mother and father
-were tinkerers in Eritz, jewelers and watchmakers, pacifists. Then:
+were tinkerers in Eritz, jewelers and watchmakers, pacifists. They are named **Amar** and
+**Alegría**, and he has a sister, **Lucha**, a painter — but only in his character post
+(`_posts/2023-01-22-dolor-vagarpie.md`). **No chapter has ever named any of the three.** The
+prose says "his parents" every time, ch. 81 included. The names are published where a curious
+reader can find them and unspoken where it would land; that is a reveal still sitting on the
+table. Then:
 
 - Ch. 74 — a warforged book in Sigil is written in a **substitution cipher** Dolor last saw as a
   child on a timepiece component in his parents' workshop. It is not native to Eritz.

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -118,6 +118,75 @@ historical rate. **Keep** the tighter sentences and lower adverb count — those
 Em dashes are unspaced: `experience—and survival`. Your own reference note in the chapter files
 gives the Mac shortcut (Option + Shift + Dash), so this is a deliberate habit, not an accident.
 
+## Contractions — contract by default in narration
+
+Added after chapter 84, where this went wrong badly enough to be the most audible thing separating
+the draft from your prose. It survived two revision passes unnoticed.
+
+Measured on **narration only** — everything outside quotation marks, with HTML comments, link URLs
+and ch. 2's curly quotes normalised out — in contractions per 1,000 narration words:
+
+| | Chapters | Pooled | Median | Range |
+|---|---|---|---|---|
+| **You, ch. 1–77** | 74 | **16.9** | 16.7 | 7.4–46.5 |
+| — excluding the list-combat era | 55 | 17.4 | 17.1 | 8.3–35.8 |
+| — the list-combat chapters alone | 19 | 15.2 | 15.1 | 7.4–46.5 |
+| **You, ch. 56–77** | 22 | 17.6 | 16.9 | 12.0–35.8 |
+| **Claude-drafted, you-edited, 78–83** | 6 | **18.5** | 19.1 | 11.1–23.1 |
+| **Ch. 84, unedited** | 1 | **5.7** | — | — |
+
+**The drafted-and-edited chapters are not the problem — they're slightly above your own baseline.**
+78–83 pool at 18.5 against your 16.9. Every one of the six sits inside your range. Whatever your
+editing pass does to a Claude draft, it lands the narration on target or a shade past it.
+
+**Chapter 84 is not at the low end of the range. It is below the floor.** Your lowest chapter in
+77 is ch. 32 at 8.3; the lowest in the drafted run is ch. 79 at 11.1. Chapter 84 came in at 5.7 —
+under two thirds of the lowest number anywhere in the campaign, and about a third of the norm.
+
+Dialogue was never the problem in any era. Chapter 84's dialogue sits at 37.8, comfortably inside
+your 32–36. The failure is entirely in narration.
+
+The mechanism is a small set of forms that get written out instead of contracted. Raw counts, and
+the rate per 10,000 narration words:
+
+| Written out | You, 1–77 (113k words) | Drafted+edited, 78–83 (11.7k) | Ch. 84 (3.5k) |
+|---|---|---|---|
+| `it is` | 14 (1.2) | 2 (1.7) | **15 (42.8)** |
+| `does not` | 2 (0.2) | 3 (2.6) | **9 (25.7)** |
+| `that is` | 19 (1.7) | 1 (0.9) | **7 (20.0)** |
+| `they are` | 8 (0.7) | 0 (0.0) | **7 (20.0)** |
+| `there is` | 9 (0.8) | 5 (4.3) | **6 (17.1)** |
+| `he is` | 7 (0.6) | 1 (0.9) | **6 (17.1)** |
+| `is not` | 5 (0.4) | 5 (4.3) | **5 (14.3)** |
+| `are not` | 2 (0.2) | 0 (0.0) | 2 (5.7) |
+| `cannot` | 14 (1.2) | 1 (0.9) | 2 (5.7) |
+| `did not` | 2 (0.2) | 0 (0.0) | 0 (0.0) |
+| **All ten, per 10k** | **7.3** | **15.4** | **168.3** |
+
+That last row is the whole finding. You write these out **7.3 times per 10,000 words** of
+narration. Your edit of a Claude draft roughly doubles that to 15.4, which is still rare enough to
+be invisible. Chapter 84 ran at **168.3 — twenty-three times your rate.**
+
+Concretely: you wrote "does not" **twice in three years and 113,000 words.** Chapter 84 used it
+**nine times in one chapter.**
+
+**So: write `doesn't`, `isn't`, `can't`, `won't`, `wouldn't`, `hasn't`, `it's`, `that's`,
+`there's`, `they're`.** In your voice the expanded form isn't neutral — it reads as emphasis, and
+it only lands if it's rare. Chapter 84's one genuinely earned use:
+
+> He is not messing with them.
+
+That works because the line before it is a character claiming the opposite. But "and does not take
+the head off" three scenes earlier earns nothing; it's just stiff. The fix is almost always
+mechanical — contract it and move on.
+
+Watch for it particularly in these two places, which is where they cluster:
+
+- **Negated present-tense narration**, which this campaign runs on: "he does not press him,"
+  "distance does not hold still," "Mond does not ask a single question." All three want `doesn't`.
+- **Single-sentence paragraphs used as punctuation**, where the expanded form sounds portentous:
+  "One of them does not." → "One of them doesn't."
+
 ## Voice
 
 **Third person, present tense, always.** "Mond hangs from a rung of the ladder." Past tense only

--- a/_posts/2023-01-22-gven-vetkam.md
+++ b/_posts/2023-01-22-gven-vetkam.md
@@ -13,7 +13,7 @@ tags:
 
 ## Statistics
 
--   **Name:** Gven Vatkem (guh·ven vat·kem)
+-   **Name:** Gven Vetkam (guh·ven vet·kam)
 -   **Species:** [Half-orc](https://www.dndbeyond.com/species/2-half-orc) 
 -   **Class:** [Barbarian](https://www.dndbeyond.com/classes/barbarian) 
 -   **Gender:** Female
@@ -27,7 +27,7 @@ _[Character sheet at D&D Beyond](https://www.dndbeyond.com/characters/91974479/7
 
 On a blistering hot sunny day 23 years ago, in the grassy plains of The Badlands, a female half-orc baby entered the world unlike most others, with an uncharacteristically calm demeanor. She didn't scream or fuss or cry, rather, she quietly took in her surroundings, seeming to catalog everything of practical use. At least that's the story that Chok (chaak) and Gwendolyne Silje (gwen·doh·line sil·yuh) of the Sky Bisons tribe, Gven's (guh·ven) parents, like to tell anyone who will listen. 
 
-While Gven Vatkem (vat·kem) has the physical size, muscle, and passion of her father's half-orc heritage, she has also learned that it's often wiser to be silent. This affords her the time and opportunity to listen, observe, analyze, and consider her options before deciding to unleash the barbarian's rage that she knows how to use so well. Her parents have helped her cultivate these skills as she's grown older and stronger, skills that are particularly uncharacteristic for half-orcs, such as herself. 
+While Gven Vetkam (vet·kam) has the physical size, muscle, and passion of her father's half-orc heritage, she has also learned that it's often wiser to be silent. This affords her the time and opportunity to listen, observe, analyze, and consider her options before deciding to unleash the barbarian's rage that she knows how to use so well. Her parents have helped her cultivate these skills as she's grown older and stronger, skills that are particularly uncharacteristic for half-orcs, such as herself. 
 
 As a young adult half-orc, Chok was a traveling blacksmith of exceptional skill. He eventually settled with the Sky Bison tribe, where he was tolerated, even accepted by some, despite his orc heritage. Gwendolyne was the tribe's fiercest barbarian warrior, most astute tracker, and determined hunter. She was also a voice of reason, maturity, and leadership in the tribe, despite her young age. She was loved and respected by all members of the tribe. 
 

--- a/_posts/2026-08-03-chapter-84.md
+++ b/_posts/2026-08-03-chapter-84.md
@@ -1,0 +1,500 @@
+---
+title: "Chapter 84"
+show_date: true
+date: 2026-08-03T17:00:00-00:00
+sessiondate: "August 3, 2026"
+modified: 2026-08-03
+categories:
+  - campaign
+tags:
+  - co-written-with-claude
+  - eve-of-ruin
+  - fight
+  - landro
+  - levelup
+  - mournland
+  - rod-of-seven-parts
+  - sanctum
+---
+
+There is no dawn inside a colossus. The companions wake on a bed of rubble in the ruin of Landro's chest with no way to tell whether they have slept through a morning or halfway into an evening. Somewhere out of sight the gray fluid ticks along a seam it found decades ago. Nothing in the chamber has changed while they slept, and nothing in it keeps time.
+
+---
+
+Grindlefoot has the last watch, and the last watch is where the halfling does his thinking.
+
+He has been a dire wolf, a velociraptor, a giant wolf spider, and once, memorably, a badger. He counts them off and finds a gap in the tally that won't leave him alone. He has never been a frog.
+
+What follows is the serious question of what the best possible frog would be. He looks across the rubble at Bilwin, asleep on his back with his beard rising and falling on his chest, and the answer arrives whole.
+
+A dwarf frog. There is, it turns out, such a thing.
+
+The change comes easy, the way it always does now. The chamber goes enormous—rubble into hills, the ladder into a scaffold running up out of sight. The red crystal at his throat has come with him, its bronze setting warm against his skin, exactly as it was built to do. His fingers are sticky and webbed and altogether excellent. He hops twice, for research.
+
+After several minutes hopping around, investigating the foreign sights and smells, he reaches for his own shape and nothing comes back.
+
+He tries again, without hurry. There's no pain in it and no alarm, only a door that used to open and now doesn't. The halfling sits in the dark on a piece of Cyran debris and notices, in a distant and uncomfortable way, that it took him a moment to want the door to open at all.
+
+Then he starts shouting, and what comes out is a ribbit.
+
+---
+
+The others wake to find Grindlefoot gone and a frog where he was sitting.
+
+It takes the better part of an hour. The frog hops onto Bilwin's boot and is removed. The frog arranges four pebbles into what it privately considers an unambiguous diagram of a halfling. Gven crouches with her elbows on her knees and studies it.
+
+"It's a frog," she says.
+
+"Obviously," responds Mond.
+
+"No, I mean Grindlefoot's a frog. Look closely, there's his little ruby collar."
+
+The frog responds with an excited hop followed by a loud "Ribbit!"
+
+Mond looks down at it. "Well. This has been a ribbeting conversation."
+
+"Ribbit."
+
+"There it is."
+
+Gven picks the frog up in one hand, careful not to jostle the tiny creature, and tucks him inside her longcoat. "Be careful in there. Don't get smashed."
+
+For the rest of the day the companions hear intermittent muffled ribbits from somewhere around the half-orc's shoulders and chest. Every so often, she feels the deliberate progress of four small suction-cupped feet across the back of her neck.
+
+---
+
+Before they leave the chamber, Bilwin goes to Glaive.
+
+The warforged lies where it fell, the polearm still in the ruin of its hand, the carved letters across its chest catching what little light there is. The dwarf had watched Gven crouch over the body the night before and had wanted to do it in his own way. He plants himself at the warforged's feet, sets his holy symbol against his palm, and gives it a warrior's last rites—the long dwarven form, the one for a soldier who died on their feet doing what they believed they were for. It isn't a short prayer. Only Gven understands the words, yet no one interrupts.
+
+Dolor waits until Bilwin finishes before raising the obvious problem.
+
+"Is it dead?"
+
+"It hasn't moved in eight hours," Bilwin says.
+
+"Neither had Filch."
+
+That lands. Filch had lain in a tunnel not two days behind them, powered down and silent for longer than any of them had been alive, and had woken up asking where Mercy had been.
+
+"We could take the head off," Mond offers.
+
+Shaking his head at the sorcerer's suggestion, Dolor offers, "Let me look first."
+
+The tiefling kneels beside the body and works over it—the joints, the plating, the seams where a charge might still be sitting. He grew up in a workshop full of small things that were only pretending to be still, and he knows the difference between a mechanism that's waiting and one that's finished.
+
+"There's nothing left in it," he says, and stands. "Its head remains where it is, at least by our hands."
+
+---
+
+They go back to the spinal shaft and start climbing toward the head.
+
+Dolor doesn't bother with the rungs. He lifts off the floor and rises up the throat of the colossus at his own pace, a long dark tunnel with nothing in it, the ladder falling away below him. Gven leads the others up by hand, which is slower, and involves a bit of swearing from more than one companion.
+
+The tiefling reaches the top well ahead of them. The shaft opens into a chamber roughly fifteen feet by twenty, and at the far end of it the metal simply stops and the Mournland begins—a three-foot lip of floor, and then open air. He's standing in Landro's mouth.
+
+There's machinery down both sides of it, or what used to be machinery, broken back to brackets and stubs. In the center is a cradle of heavy mountings, empty, sized for a cylinder the length of a longboat. A cannon, and not a small one. Dolor crouches over the mountings and finds no cut marks, no bolts backed out, nothing done with tools by anybody. The thing was torn out. Whatever happened here happened all at once and from the inside.
+
+He walks to the lip and looks out. Gray, and a different gray, and small dark shapes a very long way down.
+
+"Anything?" Gven calls up.
+
+"Nothing worth having."
+
+"My favorite kind of room," says Bilwin.
+
+---
+
+Next level up, the shaft opens through the floor of the head.
+
+It's larger, twenty by thirty-five, with the ceiling a good fifteen feet overhead, and it would feel spacious if there were any room in it. Pipes cross the ceiling and run down the upper walls, tangled with rusted chains, and several of them are weeping. A deep red light moves through the pipes in a slow pulse, coursing along them and gathering, and every line in the chamber converges on a dais at the center.
+
+On the dais is a brain. It stands ten feet across and nearly as high, carved or cast out of ceramic, folded and lobed like the real thing and covered over every surface with grooves. The companions have seen runes cut into a great many objects by now. These aren't runes. They're older and more patient, and the eye follows them around the curve of the thing and comes back to where it started without meaning to.
+
+Along the front is a crack. Gray fluid seeps out of it and pools around the base of the dais, the same fluid they have been stepping over and around since they entered the Mournland.
+
+Eight feet above the brain, floating, scattering light in thin lines across the ceiling, is a small slender object.
+
+Bilwin feels the piece he already carries answer it.
+
+"That's it," the dwarf says. "That's the third piece."
+
+Mond notices the other thing, and only because he stops talking long enough to hear it. Under the drip of the pipes there's a voice. It's been there since they came up through the floor, low and continuous and not quite words, the sound of somebody muttering to themselves three rooms away. When he holds still and listens for it directly, it thins out to nothing. When he stops trying, it comes back.
+
+"Does anyone else hear that?"
+
+"I thought it was the pipes," Grindlefoot says, from inside the longcoat, except that what he says is a ribbit, and nobody understands it.
+
+Gven looks up at the rod, then at the brain, then at the eight feet of empty air in between. "Can you reach it?"
+
+"I can throw the frog," Mond suggests.
+
+A ribbit from inside the half-orc's longcoat, furious.
+
+"Bilwin." Gven doesn't take her eyes off the ceiling. "The floating hand. You've got the floating hand."
+
+The dwarf opens his mouth to say something, closes it, and stands there with the expression of a dwarf being handed his own house keys.
+
+"I do have the floating hand," he says.
+
+"You've had it the whole time."
+
+"I've had it the whole time." He's already delighted with himself again. He raises a [Mage Hand](https://www.dndbeyond.com/spells/2619008-mage-hand) and sends it drifting up toward the rod.
+
+The muttering stops.
+
+Then it comes back at volume, from everywhere at once, and it is still not talking to them.
+
+*Are they here? They are here. Do they know who I am. What are they doing. They are just standing there. Do they know what they are doing—*
+
+The companions stop moving. The Mage Hand stops with them, hanging in the air.
+
+*Do you think they can hear us,* the voice says, to itself, and then, in a different register entirely, careful and formal and pitched at the room: "That is rude. Put that away, please."
+
+Bilwin is momentarily confused, then lowers the magic hand.
+
+The pooled fluid at the base of the dais draws itself up off the floor. It comes thick and unhurried, heavy as cold honey climbing a spoon, gathering into a shape with a head and shoulders and arms and nothing below the waist but a moving column. Where a face would be there are two dim red points that settle on each of them in turn. It holds its shape. Water wouldn't.
+
+"Wait a minute," Gven says. "Who are you?"
+
+"You are in my house," the figure says. "It is my house. I apologize. I have not—" It stops. "I apologize. My vocabulary is not what it should be. I have not had a use for words in some time. I am not certain how much time."
+
+"We come from another place," Dolor says.
+
+"That is quite clear. You were not here before. Therefore the only logical conclusion is that you came from another place." A pause. "Another plane. That is very interesting. I had not concluded that."
+
+"Do you have a name?"
+
+The figure considers the question at length, and the red eyes dim and brighten while it does.
+
+"I am Landro," it says.
+
+---
+
+For a while nobody says anything, and the thing that was a puddle a minute ago waits with what can only be described as patience. It's the size of a tall man and it doesn't stand like one. It sways where it is, gathering and settling, the red light in the pipes overhead pulsing in the same slow rhythm, and the companions understand without discussing it that they aren't looking at something that lives in the colossus. Gven takes her hand off Tempest Edge. Bilwin, who has walked into every room in the Mournland first and without thinking, stays exactly where he is.
+
+"What's the last thing you remember?" Dolor asks.
+
+The chamber goes quiet enough that everyone can hear the pipes dripping.
+
+"War," Landro says. "We were going to war. I was coming online. And then something happened, and we became stuck, and they could not get out." The voice thins as it goes, moving away from them without the figure moving at all. "They tried to get out. They tried to free me. I was broken and I could not help them with anything at all. They died here. I have been here."
+
+Dolor steps closer to the dais. "Is there anything we can do for you?"
+
+The red eyes turn to him and hold.
+
+"My memory stops," Landro says. "I have not learned anything new. I would like to learn. Perhaps you would share a memory with me."
+
+"How does that work?"
+
+"It is harmless. It takes a moment. It requires contact."
+
+A ribbon of the gray fluid extends from the figure's arm, thin as a finger, and hangs in the air between them.
+
+"Careful," Gven says. "You know what that stuff does."
+
+"I know exactly what it does." Dolor is already tilting his head forward. He has had this fluid on his boot once already, in a tunnel two levels down, and what it gave him then he hasn't repeated to anyone. "One question. How do I choose which memory you take?"
+
+"You do not. I promise I will take only the first I find."
+
+The ribbon touches his forehead.
+
+What Dolor hears is a deep slosh that fills his ears, and then he's under—all the way under, dark water pressing on him from every direction, the pressure of it in his teeth. It goes on. It goes on long enough that he needs to breathe, and then longer.
+
+Then it's gone, and he's standing dry on the floor of the chamber, and the others are looking at him, and it has been an instant.
+
+Landro is very still.
+
+"Ah," it says.
+
+What it took was the newest thing he had. A tunnel two days behind them. A warforged named Mercy with both arms around the whole body of a friend they had spent decades not looking for, talking too quietly to be heard until the clicking started. And underneath it, the question the pilgrims of Ialos put to one another on the road: *did you choose your name, or was it given?*
+
+"My poor brethren," Landro says. "No definition of meaning is a lonely place to be."
+
+"They're finding their own meaning," Dolor says.
+
+"That is a noble endeavor." The red eyes move over each of the companions in turn. "It is fraught with peril, if you choose it."
+
+Nobody fills the silence after that.
+
+---
+
+"May I have another?"
+
+"Not just now." Dolor gestures up at the floating rod. "That's why we're here. That piece belongs to an artifact we're assembling, to stop someone who means to take every plane there is and remake all of them in his own image."
+
+"That does not sound good."
+
+"We don't think it is."
+
+"What does it do for you?" Bilwin asks. "The rod. What's it for?"
+
+Landro's column of fluid gestures, loosely, at the gray pooled around the dais. "That is what keeps me functional. Without it I am—" the gesture again, at the floor. "The rod is not me. It merely allows me to focus."
+
+Then it goes quiet, and leans, and looks at Dolor closely.
+
+"You look familiar."
+
+The tiefling says nothing at all. He has been saying nothing since the tunnel where he heard his parents' voices calling out charge levels, and nothing since the pilot's helmet with their workshop mark faded into the silver, and he says nothing now.
+
+The red eyes move on to Bilwin, and stop.
+
+"You," Landro says. "You came back."
+
+Bilwin blinks. "I did?"
+
+"Yes."
+
+"When was I here before?"
+
+"You were here before."
+
+The dwarf stands with his mouth open and reaches for it, and reaches for it, and finds the same smooth blank wall he always finds, the one that has been there since before Wayside, since before any of these people knew him. A company of dwarves. A piece of this same rod. Somebody who played better than he does.
+
+"I need to think on this," he says, which isn't something Bilwin usually needs.
+
+Landro doesn't press him. "I wonder," it says instead, "whether you would be willing to let me come with you."
+
+Gven raises an eyebrow. "You're the construct, this thing we're inside, that's buried in the side of a mountain."
+
+"The construct is not me either." The figure turns, and the red eyes come up bright. "Before I was here I was in a crystal. A small one, cut for the purpose. If you were to find one, I could transfer myself into it."
+
+"Yes!" Bilwin says, before anyone else can open their mouth.
+
+Dolor is already going through his pockets. He comes out with the gemstone he eased from the dead pilot's hand a level below, cut the way the stones in his parents' shop were cut, that light goes into and doesn't come out of. He holds it up.
+
+"Will this do?"
+
+"Oh," Landro says. "Yes. Most definitely."
+
+"That was promised to Ialos," Gven says.
+
+"They get the helmet," Dolor says. "I think they'd take the trade."
+
+Mond has been quiet for most of this, which is normal, and is looking at his staff, which isn't. He steps forward and holds it up beside the floating crystal.
+
+"Would you like me to set it here? At the top. You'd travel where we travel, out in the open, where you can see it."
+
+The pause before Landro answers is a long one.
+
+"I would like that very much."
+
+---
+
+"Before we do this," Dolor says. "Does anything happen when you leave the construct?"
+
+"Yes. It self-destructs in one minute."
+
+Gven turns to the others. "Oh, great."
+
+"There are also security protocols," Landro adds. "Those do not wait a minute. Those are immediate."
+
+What follows is several minutes of argument conducted in low voices at the edge of the dais, most of it about who is standing where and in what order, some of it about whether a spell that turns a person into a cloud can be made to move a cloud faster. Gven is immovable on one point and says so twice. Bilwin proposes something involving the frog and is voted down. Eventually they stop talking and start moving, which amounts to the same thing.
+
+Gven reaches into her longcoat and hands the frog over. Dolor puts a very small wild-shaped halfling into his jacket pocket and buttons it.
+
+Three of them go down the shaft. One of them doesn't.
+
+---
+
+Down in the mouth, the half-orc plants herself in the middle of the floor with the Mournland at her back and folds her arms.
+
+"I'm not going any further until Dolor is safe."
+
+Mond and Bilwin take up positions beside her, and wait.
+
+---
+
+Above them, Dolor flies up level with the floating rod, close enough to touch it, and holds out the crystal.
+
+"Are you ready?"
+
+"Yes," Landro says.
+
+The gray fluid reaches out and touches the gemstone.
+
+Several things happen at once. The entire colossus shudders, hard enough that three floors below a half-orc, a dwarf and a half-elf all have to fight for their footing; all of them keep it. The red light in the pipes goes out. The magic holding the rod in the air quits, and Dolor snatches the piece out of its fall.
+
+Four panels around the chamber pop open, and out step four warforged. They're built differently to the blade scouts. They have no weapons in their arms at all, only hands.
+
+And Landro's voice, everywhere, out of every pipe, in the head of its own body, perfectly calm:
+
+"Self-destruct sequence initiated. Sixty. Fifty-nine."
+
+<!-- Fight choreography: Landro's guardians -->
+
+<!-- Initiative rolls:
+Gven - 22
+Bilwin - 22
+Mond - 12
+Dolor - 10
+Guardians (x4) - 13
+Note: Gven, Bilwin and Mond are down in the mouth, not the head. Dolor fights this one alone.
+-->
+
+<!-- Round 1 -->
+
+They come up the sides of the brain to reach him, climbing the ceramic to close the gap, and they swing with their fists.
+
+The first guardian throws two punches and hits nothing but air. The second and third reach him together and miss together. The fourth catches him square, a blow with the colossus's whole design philosophy behind it; Dolor rolls with it and [dodges](https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#UncannyDodge) most of what it meant to do to him.
+
+Then he turns sideways and runs away, which is the correct answer and usually has been. He disengages, dives for the hole in the floor, and goes down the throat of the colossus at speed with the third piece of the [Rod of Seven Parts](https://forgottenrealms.fandom.com/wiki/Rod_of_Seven_Parts) in his fist.
+
+<!-- Round 1 damage:
+Dolor - 14 bludgeoning (guardian 4), halved to 7 via Uncanny Dodge
+Note: Dolor Dashed as his action and Disengaged as a bonus action, so no attacks of opportunity.
+The guardians did not pursue past the head. No other party members engaged.
+-->
+
+---
+
+The three in the mouth see him coming before they hear him.
+
+"GET OUT!"
+
+Mond doesn't ask a single question. He casts [Gaseous Form](https://www.dndbeyond.com/spells/2618968-gaseous-form) on Gven, then on Bilwin, then on himself, and three clouds of pale vapor come apart where the three were standing. They drift out over the lip of Landro's mouth into open air.
+
+They float. That's the trouble with the spell. They're moving at the speed of a leisurely stroll, out of the mouth of a building that has announced it's going to explode, and they can't go any faster. Behind them Landro's voice is coming up through the metal—forty-one, forty, thirty-nine.
+
+Dolor jumps after them with a frog buttoned into his pocket and flies down past them to the ground, where he waits.
+
+It's somewhere in the descent that all four of them hear it, inside their heads, in the calm and courteous voice of a war machine currently counting down to its own destruction:
+
+*There are free donuts at the eldercare facility.*
+
+Nobody has anything to say about that, then or later.
+
+---
+
+They reach the ground. The spell ends, and Gven, Bilwin and Mond come back together out of the air with the Mournland fog moving around their ankles.
+
+*Ten. Nine.*
+
+They run.
+
+The explosion goes off behind them and above them, and the whole enormous body of the colossus opens outward at once, and pieces of Landro go out across the dead gray plain in every direction. For a moment the Mournland is bright. It's the only real light any of them have seen since they came here, and none of them look back at it long.
+
+In the ringing afterward, a small voice in four heads says, mildly:
+
+*I feel disembodied. That is weird.*
+
+"That's what you find weird?" Bilwin says.
+
+---
+
+They stop for an hour so Mond can do the job properly, seating the crystal into the head of his staff and binding it there. Grindlefoot, the African dwarf frog, watches intently.
+
+Later, as the group walks towards the portal, Grindlefoot finds the door to his natural state available again. Riding on Dolor's shoulder, he announces his intention with a "Ribbit" and leaps, transforming mid-air into his three foot tall halfling body, deftly landing on the rocky ground next to Dolor. He flourishes the bowler hat that reappeared with him and falls in-step with the others.
+
+"Mond, mind if I have a look at your staff? I have an idea." The group pauses and the sorcerer hands over his wooden staff. Grindlefoot turns it over in his hands, studying the grain of the wood and how it meets the crystal. With a little [Druidcraft](https://www.dndbeyond.com/spells/2618977-druidcraft), the wood at the top of the staff wakes up and grows—curling up and over the crystal in fine arcane whorls, closing around it, locking it in. It's good work. It's the work of somebody making sure a passenger can't be shaken loose.
+
+*This is much better,* Landro says.
+
+The walk back to the portal ought to be hard. In this place the road back is never the road you walked in on, and distance doesn't hold still. But Grindlefoot has been tracking his own trail since the moment they stepped through the obsidian, frog or otherwise, and he takes them across it in a little under three hours.
+
+Landro talks the entire way.
+
+*Those are trees.*
+
+"They are," Dolor says.
+
+*And that is ground.*
+
+"Also true."
+
+*You walk on the ground.* A pause of some length. *Why would one walk on ground?*
+
+Gven, from the front, without turning around: "It's a long story."
+
+---
+
+The portal is where they left it, twenty feet of obsidian glass standing in the mud with the party's own reflection stretched dark across it. As they come up on it the third piece stirs in Dolor's hand and throws light, and the black surface goes thin and clear, and through it they can see a room with nice furniture in it and no fog anywhere.
+
+"Anyone want to stay?" Mond asks.
+
+Nobody does. They walk through into the main parlor of the Sanctum, with three of seven pieces of the rod between them.
+
+Mordenkainen is in a leather chair, reading four books at once. He has one open in his hands and three more standing about him, their pages turn at the same moment, and he doesn't look up.
+
+"Well done," he says. "Quite good of you."
+
+"Thank you." Dolor crosses the room. "I'd like to introduce Landro."
+
+"Oh." The wizard looks away from his reading and leans toward the staff, one long finger comes out, and he taps the crystal twice, testing it.
+
+*Do not do that.*
+
+Mordenkainen's eyebrows go up half an inch, which for him is falling out of the chair.
+
+*That is extremely annoying.*
+
+"He can hear you," Bilwin says with a grin. "He's a member of the party now. Be nice."
+
+Mordenkainen returns to his four books without any visible change of expression, and from somewhere in the middle of them, still reading, still not looking up, allows that he will let the household know the adventurers are hungry and would like to rest.
+
+From the top of Mond's staff, very quietly, in the empty air of a room in Sigil, comes the sound of something pouting.
+
+_The adventurers advance to level 13._
+
+<!-- NOTES -->
+
+<!-- Third piece of the Rod of Seven Parts recovered. Its power is Reverse Gravity, DC 18, once per day
+(50 ft radius, 100 ft high cylinder). The party holds three pieces and is keeping them separate rather than
+clicking them together: commune, arcane gate, and reverse gravity.
+-->
+
+<!-- Owed to Ialos: the pilot's helmet still goes to the warforged pilgrims. The control crystal that was
+promised to them in the same breath (ch. 82) is now Landro's vessel.
+-->
+
+<!-- Open threads touched this chapter:
+  - Landro to Bilwin: "You came back." Bilwin has no memory of it. Ties to his lost dwarven company and
+    the sentence Alustriel surfaced in ch. 74 — "We will start with the one and the rest will come after."
+  - Landro to Dolor: "You look familiar." Dolor still hasn't told anyone his parents built this thing.
+  - Dolor expended a secret (taken from Mercy, ch. 78) to share the memory. The party gained heroic
+    inspiration and advantage on d20 rolls for one minute.
+  - Grindlefoot could not release a wild shape for the better part of a day. Left unexplained on the page.
+-->
+
+
+<!-- em dash: — | Mac kebyoard shortcut = Option + Shift + Dash (-) -->
+<!-- https://oatcookies.neocities.org/dndmoney to convert copper, silver, gold, and more into CP -->
+<!-- Frequently used links:
+  [Barbarian rage](https://www.thegamer.com/dungeons-dragons-dnd-barbarian-rage-explained-guide/)
+  [Bardic inspiration](https://www.dndbeyond.com/classes/1-bard#BardicInspiration-75)
+  [Chaos Bolt](https://www.dndbeyond.com/spells/14761-chaos-bolt)
+  [eagle eyesight](https://dnd5e.wikidot.com/barbarian:totem-warrior#toc2)
+  [Eldrich Blast](https://www.dndbeyond.com/spells/2619161-eldritch-blast)
+  [Green-Flame Blade](https://dnd5e.wikidot.com/spell:green-flame-blade)
+  [Guiding Bolt](https://www.dndbeyond.com/spells/2619136-guiding-bolt)
+  [Hanseath](https://forgottenrealms.fandom.com/wiki/Hanseath)
+  [Hellish Rebuke](https://www.dndbeyond.com/spells/hellish-rebuke)
+  [hurdy-gurdy](https://en.wikipedia.org/wiki/Hurdy-gurdy)
+  [Mind Spike](http://dnd5e.wikidot.com/spell:mind-spike)
+  [Shillelagh](https://www.dndbeyond.com/spells/2249-shillelagh)
+  [Spiritual Weapon](https://www.dndbeyond.com/spells/2263-spiritual-weapon)
+  [Tasha's Mind Whip](https://dnd5e.wikidot.com/spell:tashas-mind-whip)
+  [Uncanny Dodge](https://roll20.net/compendium/dnd5e/Rogue#toc_10)
+  [Wild Shape](https://www.dndbeyond.com/posts/635-druid-101-wild-shape-guide)
+    - [Giant Wolf Spider](https://www.dndbeyond.com/monsters/16900-giant-wolf-spider)
+-->
+<!--
+  Lists of spells for the classes:
+    - Bard spells (Bilwin): https://www.dndbeyond.com/spells/class/1-bard
+    - Cleric spells (Bilwin): https://www.dndbeyond.com/spells/class/cleric 
+    - Druid spells (Grindlefoot): https://www.dndbeyond.com/spells/class/druid
+    - Sorcerer spells (Mond): https://www.dndbeyond.com/spells/class/sorcerer
+    - Warlock spells (Dolor): https://www.dndbeyond.com/spells/class/warlock
+  Monsters: https://www.dndbeyond.com/monsters
+  Damage types: https://www.wargamer.com/dnd/damage-types
+  Luck (Bilwin): http://dnd5e.wikidot.com/feat:lucky
+-->
+<!-- Directions on a boat:
+  Port = left side
+  Starboard = right side
+  Bow = front
+  Aft = back (inside the ship, on board)
+  Stern = back (outside, offboard)
+-->
+
+<!-- Guest player:  -->


### PR DESCRIPTION
Chapter 84, the session of **August 3, 2026** — the party wakes inside Landro, meets the colossus's mind, trades the pilot's control crystal for its passage out, and clears the mouth one minute ahead of the self-destruct with the third piece of the Rod.

Drafted from the voice notes and audio transcript, then revised twice against inline review notes, then synced with the hand-edited version in the `Final edit - markdown` tab. Tagged `co-written-with-claude`.

## The chapter

`_posts/2026-08-03-chapter-84.md` — 4,200 words, eight tags, all pre-existing in the corpus. Combat is one round, prose only, mechanics in HTML comments. Front matter validated with the same YAML parser Jekyll uses.

## Reference files, updated with what the drafting turned up

**`.claude/characters.md`**
- **Dolor's fighter-feature question is closed.** It was listed as open — Second Wind in ch. 36, Action Surge twice in ch. 38, neither fitting Rogue & Warlock. The answer was in a comment block in his own character post: respecced to Rogue 5 / Warlock 3, genie patron, Pact of the Blade with Gleaming Blade as the pact weapon. The martial levels were traded away *in the fiction*, not retconned.
- **Family names added** — parents Amar and Alegría, sister Lucha — flagged precisely: published in his character post, but never named in any of the 81 chapters, including the whole Landro arc that is built on his parents. Ch. 81 says "his parents." That reveal is still unspent.
- **Mond's staff recorded**, origin marked unrecorded, plus the 5'9"/5'10" height discrepancy between his post and the source doc.

**`.claude/story-so-far.md`** — the same family names, with the same reveal caveat.

**`.claude/writing-voice.md`** — new **Contractions** section, measured rather than asserted. Narration only, contractions per 1,000 words:

| | Pooled | Median | Range |
|---|---|---|---|
| Ch. 1–77 | 16.9 | 16.7 | 7.4–46.5 |
| Ch. 78–83 (drafted, then edited) | 18.5 | 19.1 | 11.1–23.1 |
| Ch. 84 first draft | **5.7** | — | — |

The drafted-and-edited chapters sit slightly *above* the author's own baseline, so this was never a drafted-vs-written divide. Chapter 84's first draft came in below the floor of every chapter in the campaign. "does not" appears twice in 113,000 words of the author's narration; that draft used it nine times in one chapter. Fixed here — narration now runs 18.2.

**`_posts/2023-01-22-gven-vetkam.md`** — "Vatkem" corrected to "Vetkam" in the two body instances, matching the post title, filename, permalink, and appendix entry. Repo-wide check confirms no incorrect spelling remains.

## Verification

- Front matter parses; every tag already exists in the corpus
- All spell links reuse IDs already present in the repo — none invented
- Zero spaced em dashes; the four measured LLM tics at zero
- Spellcheck pass including `halfing`, which spellcheck won't flag

The site was not built locally — `bundle install` has never been run in this checkout, so Jekyll isn't available. Front matter was validated with Ruby's YAML parser instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)