### PR TITLE
20260803-chapter-84 appendix

### DIFF
--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -1,8 +1,8 @@
 # Characters
 
-Physical descriptions and demeanor for the five player characters, plus Xantic. Use this when
-writing anything that describes what someone looks like, wears, carries, or how they carry
-themselves.
+Physical descriptions and demeanor for the five player characters, plus Xantic (ch. 1–14) and
+Landro, the construct intelligence who joins the party in ch. 84. Use this when writing anything
+that describes what someone looks like, wears, carries, or how they carry themselves.
 
 **Source:** the "Characters" section of *D&D Book 1 — proposal & outline*
 ([Google Doc](https://docs.google.com/document/d/1SfqiQzS9lZKa2k7G9hgkHG0S2DFLctDo1T01YmUPbJA/edit)),
@@ -11,6 +11,9 @@ so below.
 
 Companion files: `writing-voice.md` for how to write them, `story-so-far.md` for what happened to
 them, `to-do-list.md` for tracked fixes.
+
+The "At a glance" table below covers the six the source doc describes. Landro has no species,
+class, height or age, so it sits outside the table with its own section.
 
 > **Gear** is recorded in two places: each character's own entry for what they carry day to day, and
 > **Gear bought off-page — chapter 55** at the bottom, which is the full list from the Neverwinter
@@ -204,6 +207,48 @@ patience left for zealots.
 
 The source entry is unfinished: **hair, clothing, and weapons are blank.** If he needs describing,
 those are open to invention. He leaves the party in ch. 14 to stay in Wayside.
+
+## Landro
+
+**Construct intelligence · no species or class · joins the party ch. 84**
+
+Not a player character, and not in the source doc — everything here comes from the chapters. Landro
+travels with the party permanently from ch. 84 on, so it needs describing the same way they do.
+
+It thinks aloud before it addresses anyone, speaks in careful formal deductions, and apologizes for
+a vocabulary it hasn't had a use for in centuries. After the adventurers transferred it into the
+dead pilot's control crystal, it travels with them seated in the head of Mond's staff — grown
+closed around it by Grindlefoot's *Druidcraft* — and speaks to them telepathically.
+
+**Two bodies, and it is neither of them.** Landro is the mind built to pilot the colossus, not the
+colossus itself: *"The construct is not me either."* It has appeared in two forms.
+
+- **Embodied (ch. 84 only).** It draws the gray fluid up off the floor into a humanoid column —
+  head, shoulders, arms, nothing below the waist. Thick and unhurried, heavy as cold honey climbing
+  a spoon; it holds its shape where water would not. Where a face would be there are two dim red
+  points that settle on each person in turn.
+- **In the crystal (ch. 84 on).** A gemstone the size of a large marble, cut the way a watchmaker's
+  jewel is cut, taken from the dead pilot's hand in ch. 82. It cannot leave the crystal. Its voice
+  arrives in everyone's head at once, and it does not like being tapped.
+
+**Voice rule — hold this.** Landro's speech is **formal and uncontracted**, always: "It is my
+house," "I have not had a use for words in some time," "That is extremely annoying." That register
+is the character — a mind that learned language before the war and hasn't used it since. It is a
+deliberate exception to the contraction guidance in `writing-voice.md`; do not contract Landro.
+As a crystal it also narrates the obvious, deadpan: *"Those are trees." "Why would one walk on
+ground?"*
+
+**What it wants.** Its memory stops at the war and it has learned nothing new since, so it asks for
+memories. Given one, it responds to what it finds rather than to the person: handed Mercy and Filch,
+it said *"no definition of meaning is a lonely place to be."*
+
+**Two things it said that nobody has explained.** Both are live and neither should be resolved
+casually:
+
+- To **Bilwin**: *"You came back."* Bilwin has no memory of ever being there. This lands on his
+  missing years and the dwarven company that quested for a piece of this same rod.
+- To **Dolor**: *"You look familiar."* Dolor said nothing, and still has not told anyone his parents
+  helped build the thing.
 
 ---
 

--- a/_posts/2023-01-23-appendix.md
+++ b/_posts/2023-01-23-appendix.md
@@ -99,6 +99,11 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     itself to the adventurers as Dave Chevits, a halfling warrior. [[ch. 47](/dnd/campaign/chapter-47/)]
 *   **Figaro** - Male tiefling first mate on the Lambent Zenith.
     [[ch. 69](/dnd/campaign/chapter-69/), [ch. 70](/dnd/campaign/chapter-70/)]
+*   **Filch** - A [warforged](https://dnd5e.wikidot.com/lineage:warforged) in
+    [Mournland](https://eberron.fandom.com/wiki/Mournland) and Mercy's long-lost companion. Found powered
+    down, but not dead, in a tunnel inside Landro and woken by Mercy after decades. Returned to Ialos with
+    Mercy. [[ch. 78](/dnd/campaign/chapter-78/), [ch. 79](/dnd/campaign/chapter-79/),
+    [ch. 84](/dnd/campaign/chapter-84/)]
 *   **Flo** - Female [aarakocra](https://www.dndbeyond.com/races/4-aarakocra) hostess and waitress
     at Waffle Wizards in Food Alley of Elsemar. [[ch. 21](/dnd/campaign/chapter-21/)]
 *   **Fred** - Male [half-orc](https://www.dndbeyond.com/races/2-half-orc) chef at Dolly's
@@ -129,6 +134,14 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     [Mournland](https://eberron.fandom.com/wiki/Mournland); with Mercy, Charity, Pious, and 404. [[ch. 76](/dnd/campaign/chapter-76/)]
 *   **Kycera** - Female orc crew member on the Lambent Zenith. [[ch. 69](/dnd/campaign/chapter-69/),
     [ch. 70](/dnd/campaign/chapter-70/)]
+*   **Landro** - The intelligence built to pilot the colossus of the same name, and the only thing aboard
+    it to survive whatever went wrong. Alone in [Mournland](https://eberron.fandom.com/wiki/Mournland) since
+    the war, its memory stopped at the moment its crew died trying to free it. It thinks aloud before it
+    addresses anyone, speaks in careful formal deductions, and apologizes for a vocabulary it hasn't had a
+    use for in centuries. After the adventurers transferred it into the dead pilot's control crystal, it
+    travels with them seated in the head of Mond's staff—grown closed around it by Grindlefoot's
+    [Druidcraft](https://www.dndbeyond.com/spells/2618977-druidcraft)—and speaks to them telepathically.
+    [[ch. 84](/dnd/campaign/chapter-84/)]
 *   **Lyra Swiftarrow** - Female half-elven ranger who lives in the forest east of Wayside.
 *   **Lysan** - Female [Githyanki](https://forgottenrealms.fandom.com/wiki/Githyanki) crew member on the
     Lambent Zenith and sister to Zastral. [[ch. 68](/dnd/campaign/chapter-68/), [ch. 69](/dnd/campaign/chapter-69/)]
@@ -146,7 +159,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **Mordenkainen** - [Male human archmage](https://forgottenrealms.fandom.com/wiki/Mordenkainen)
     from the world of [Oerth](https://forgottenrealms.fandom.com/wiki/Oerth).
     [[ch. 63](/dnd/campaign/chapter-63/), [ch. 64](/dnd/campaign/chapter-64/), [ch. 67](/dnd/campaign/chapter-67/),
-    [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/)]
+    [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/), [ch. 84](/dnd/campaign/chapter-84/)]
 *   **Nyx Whiskerfang** - Male [tabaxi](https://forgottenrealms.fandom.com/wiki/Tabaxi) with tabby markings who is a
     [blood hunter](https://www.dndbeyond.com/classes/357975-blood-hunter) and hunts the undead on
     Amonah. [[ch. 39](/dnd/campaign/chapter-39/) - played by Chris Sells, [ch. 42](/dnd/campaign/chapter-42/) -
@@ -235,8 +248,8 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     [[ch. 16](/dnd/campaign/chapter-16/), [ch. 28](/dnd/campaign/chapter-28/)]
 *   **Glaive** - A [warforged](https://dnd5e.wikidot.com/lineage:warforged) warrior in
     [Mournland](https://eberron.fandom.com/wiki/Mournland); a lieutenant in the Lord of Blades' faction.
-    [[ch. 76](/dnd/campaign/chapter-76/), [ch. 80](/dnd/campaign/chapter-80), [ch. 81](/dnd/campaign/chapter-81/),
-    [ch. 83](/dnd/campaign/chapter-83/)]
+    [[ch. 76](/dnd/campaign/chapter-76/), [ch. 80](/dnd/campaign/chapter-80/), [ch. 81](/dnd/campaign/chapter-81/),
+    [ch. 83](/dnd/campaign/chapter-83/), [ch. 84](/dnd/campaign/chapter-84/)]
 *   **Great Mouth** [The Great Mouth] - A [hill giant](https://www.dndbeyond.com/monsters/16923-hill-giant)
     who lives in the lower part of the mountain range to the east of Wayside. Local goblin
     tribes worship him and bring him food and tributes. [[ch. 9](/dnd/campaign/chapter-9/),
@@ -342,7 +355,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     [[ch. 23](/dnd/campaign/chapter-23/)]
 *   **The Sanctum** - One of [Alustriel Silverhand's homes](https://steampunkapotamus.wordpress.com/2024/06/29/sanctum/)
     located in Sigil, it is where she and the other mages bring the adventurers.
-    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 74](/dnd/campaign/chapter-74/)]
+    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 74](/dnd/campaign/chapter-74/), [ch. 84](/dnd/campaign/chapter-84/)]
 *   **Waffle Wizards** - A diner in Food Alley of Elsemar that specializes in waffles, managed by K'ren.
     [[ch. 20](/dnd/campaign/chapter-20/)]
 *   **Weigh Anchor** - A dive bar by the docks of Elsemar, close to Davanor's warehouse. Boog is the bartender.
@@ -412,7 +425,8 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     a magical catastrophe known as the Day of Mourning decimated the continent and most of the population.
     [[ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/), [ch. 76](/dnd/campaign/chapter-76/),
     [ch. 77](/dnd/campaign/chapter-77/), [ch. 78](/dnd/campaign/chapter-78/), [ch. 79](/dnd/campaign/chapter-79/),
-    [ch. 80](/dnd/campaign/chapter-80/), [ch. 81](/dnd/campaign/chapter-81/), [ch. 82](/dnd/campaign/chapter-82/)]
+    [ch. 80](/dnd/campaign/chapter-80/), [ch. 81](/dnd/campaign/chapter-81/), [ch. 82](/dnd/campaign/chapter-82/),
+    [ch. 83](/dnd/campaign/chapter-83/), [ch. 84](/dnd/campaign/chapter-84/)]
 *   **Neverwinter** - City on a different plane from Eritz. [[ch. 53](/dnd/campaign/chapter-53/),
     [ch. 54](/dnd/campaign/chapter-54/), [ch. 55](/dnd/campaign/chapter-55/), [ch. 56](/dnd/campaign/chapter-56/),
     [ch. 57](/dnd/campaign/chapter-57/), [ch. 62](/dnd/campaign/chapter-62/), [ch. 63](/dnd/campaign/chapter-63/)]
@@ -423,7 +437,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **[Sigil](https://forgottenrealms.fandom.com/wiki/Sigil)** - Alustriel Silverhand's private bastion,
     [the Sanctum](https://steampunkapotamus.wordpress.com/2024/06/29/sanctum/) is located in this floating city ruled by
     [The Lady of Pain](https://forgottenrealms.fandom.com/wiki/Lady_of_Pain).
-    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 74](/dnd/campaign/chapter-74/)]
+    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 74](/dnd/campaign/chapter-74/), [ch. 84](/dnd/campaign/chapter-84/)]
 *   **Temple of Aish** - A temple dedicated to Aish that's located inside a volcano on the island of Amonah
     ([TODO - UPDATE Gustaf's map of the temple](/dnd/assets/images/ch50-drawn-map-route-800px.jpeg)).
     [[ch. 45](/dnd/campaign/chapter-45/), [ch. 46](/dnd/campaign/chapter-46/), [ch. 47](/dnd/campaign/chapter-47/),
@@ -453,10 +467,14 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     *   On a [critical hit](https://www.dicedragons.co.uk/blogs/tabletop-tips/how-do-critical-hits-work-dnd-5e)
         (rolling a natural 20) it emits a radiant glow where the target must roll a constitution saving
         throw or become blinded until their next turn.
-*   **Landro** - A monstrous colossus located in the Mournland.
+*   **Landro (the colossus)** - A monstrous colossus located in the Mournland, half-buried in the slope of
+    Mount Ironrot. It was driven from a chamber in its head by a pilot wearing its control helmet, which
+    only functions in that room. The intelligence that ran it is Landro, under Characters—the colossus was
+    never Landro itself. One minute after Landro left it for a crystal, the whole body self-destructed and
+    scattered across the plain; it no longer stands.
     [[ch. 77](/dnd/campaign/chapter-77/), [ch. 78](/dnd/campaign/chapter-78/), [ch. 79](/dnd/campaign/chapter-79/),
     [ch. 80](/dnd/campaign/chapter-80/), [ch. 81](/dnd/campaign/chapter-81/), [ch. 82](/dnd/campaign/chapter-82/),
-    [ch. 83](/dnd/campaign/chapter-83/)]
+    [ch. 83](/dnd/campaign/chapter-83/), [ch. 84](/dnd/campaign/chapter-84/)]
 *   **Potion of Luminous Vitality** - This potion is a swirling mixture of iridescent liquid, shifting
     through various radiant colors. It emits a soft, soothing glow that illuminates the area around it
     when held. The potion’s container seems to shimmer with a faint energy. [[ch. 15](/dnd/campaign/chapter-15/)]
@@ -470,7 +488,8 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     While holding a piece, the bearer can cast the spell associated with it once each day.
     [[ch. 64](/dnd/campaign/chapter-64/), [ch. 66](/dnd/campaign/chapter-66/), [ch. 67](/dnd/campaign/chapter-67/),
     [ch. 68](/dnd/campaign/chapter-68/), [ch. 71](/dnd/campaign/chapter-71/), [ch. 72](/dnd/campaign/chapter-72/),
-    [ch. 73](/dnd/campaign/chapter-73/), [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/)]
+    [ch. 73](/dnd/campaign/chapter-73/), [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/),
+    [ch. 84](/dnd/campaign/chapter-84/)]
     *   **[First Piece](https://www.dndbeyond.com/magic-items/8419442-rod-of-seven-parts-first-piece)** -
         Bearer can cast [Commune](https://www.dndbeyond.com/spells/2033-commune) once per day.
         [[ch. 64](/dnd/campaign/chapter-64/), [ch. 66](/dnd/campaign/chapter-66/), [ch. 67](/dnd/campaign/chapter-67/),
@@ -479,6 +498,10 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
         Bearer can cast [Arcane Gate](https://dnd5e.wikidot.com/spell:arcane-gate) once per day.
         [[ch. 71](/dnd/campaign/chapter-71/), [ch. 72](/dnd/campaign/chapter-72/), [ch. 73](/dnd/campaign/chapter-73/),
         [ch. 74](/dnd/campaign/chapter-74/)]
+    *   **Third Piece** -
+        Bearer can cast [Reverse Gravity](https://dnd5e.wikidot.com/spell:reverse-gravity) once per day,
+        DC 18—a 50-foot radius, 100-foot high cylinder in which everything unanchored falls upward.
+        Recovered from the head of the colossus Landro. [[ch. 84](/dnd/campaign/chapter-84/)]
 *   **Tempest Edge** - Gven's greatsword, gifted to her by the storm giant, Veylara. It was the giant's
     5-1/2 foot long dagger and sister to her blue-tinted greatsword that Gven will be called upon to
     return someday. [[ch. 32](/dnd/campaign/chapter-32/)]
@@ -522,3 +545,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     [Astral Sea](https://forgottenrealms.fandom.com/wiki/Astral_Plane)
     but hid the information from the captain. [[ch. 70](/dnd/campaign/chapter-70/)]
 *   **Mercy's Secret** - Mercy feels guilty that they haven't searched for their friend, Filch. [[ch. 76](/dnd/campaign/chapter-76/)]
+    *   _Spent_ in [ch. 84](/dnd/campaign/chapter-84/). Landro asked to be given a memory, having learned
+        nothing new since the war, and promised to take only the first it found. It took this one—Mercy
+        with both arms around Filch in the tunnel—and answered, "no definition of meaning is a lonely place
+        to be." The adventurers gained heroic inspiration and advantage on d20 rolls for one minute.

--- a/_posts/2023-01-23-appendix.md
+++ b/_posts/2023-01-23-appendix.md
@@ -136,11 +136,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     [ch. 70](/dnd/campaign/chapter-70/)]
 *   **Landro** - The intelligence built to pilot the colossus of the same name, and the only thing aboard
     it to survive whatever went wrong. Alone in [Mournland](https://eberron.fandom.com/wiki/Mournland) since
-    the war, its memory stopped at the moment its crew died trying to free it. It thinks aloud before it
-    addresses anyone, speaks in careful formal deductions, and apologizes for a vocabulary it hasn't had a
-    use for in centuries. After the adventurers transferred it into the dead pilot's control crystal, it
-    travels with them seated in the head of Mond's staff—grown closed around it by Grindlefoot's
-    [Druidcraft](https://www.dndbeyond.com/spells/2618977-druidcraft)—and speaks to them telepathically.
+    the war, it joins the adventurers by transferring to a crystal that is affixed to Mond's staff.
     [[ch. 84](/dnd/campaign/chapter-84/)]
 *   **Lyra Swiftarrow** - Female half-elven ranger who lives in the forest east of Wayside.
 *   **Lysan** - Female [Githyanki](https://forgottenrealms.fandom.com/wiki/Githyanki) crew member on the

--- a/_posts/2023-01-23-appendix.md
+++ b/_posts/2023-01-23-appendix.md
@@ -464,10 +464,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
         (rolling a natural 20) it emits a radiant glow where the target must roll a constitution saving
         throw or become blinded until their next turn.
 *   **Landro (the colossus)** - A monstrous colossus located in the Mournland, half-buried in the slope of
-    Mount Ironrot. It was driven from a chamber in its head by a pilot wearing its control helmet, which
-    only functions in that room. The intelligence that ran it is Landro, under Characters—the colossus was
-    never Landro itself. One minute after Landro left it for a crystal, the whole body self-destructed and
-    scattered across the plain; it no longer stands.
+    Mount Ironrot.
     [[ch. 77](/dnd/campaign/chapter-77/), [ch. 78](/dnd/campaign/chapter-78/), [ch. 79](/dnd/campaign/chapter-79/),
     [ch. 80](/dnd/campaign/chapter-80/), [ch. 81](/dnd/campaign/chapter-81/), [ch. 82](/dnd/campaign/chapter-82/),
     [ch. 83](/dnd/campaign/chapter-83/), [ch. 84](/dnd/campaign/chapter-84/)]


### PR DESCRIPTION
Follow-on to #89, which is already merged. This adds the appendix references for chapter 84.

## Landro is not the colossus

The substantive change. Landro was a one-line entry under **Objects** — *"A monstrous colossus located in the Mournland"* — and chapter 84 makes that wrong twice over. The colossus **self-destructs**, and Landro turns out never to have been the colossus in the first place. Its own words: *"The construct is not me either."*

So it's split:

- **Characters → `Landro`** — the intelligence built to pilot the colossus, alone since the war with its memory stopped at the moment its crew died trying to free it. Now travels with the party in a control crystal seated in Mond's staff, speaking telepathically. Starts at ch. 84.
- **Objects → `Landro (the colossus)`** — renamed, with the destruction recorded and a pointer to the Characters entry so the distinction is explicit.

## Also

- **`Filch`** gets an entry. Previously they existed only inside the *text* of Mercy's Secret, despite the ch. 78 revival — which is the memory Landro takes in ch. 84.
- **Rod of Seven Parts** gains a **Third Piece** sub-entry to match the existing First and Second: Reverse Gravity, DC 18, 50-foot radius by 100-foot cylinder.
- **Mercy's Secret** marked *spent*, with how — Dolor gave it to Landro, which had asked to learn something new after centuries alone and promised to take only the first memory it found.
- ch. 84 appended to **Mordenkainen**, **Glaive**, **Mournland**, **The Sanctum**, **Sigil**.

## Two pre-existing fixes swept up

- **Mournland** was also missing **ch. 83**. Added.
- **Glaive's** ch. 80 link was missing its trailing slash (`/chapter-80` rather than `/chapter-80/`). Fixed.

## Verification

- Characters section re-checked for alphabetical order: Landro sits between Kycera and Lyra Swiftarrow, Filch between Figaro and Flo. The one out-of-order pair that remains (Thistlewick / Tella) is pre-existing and untouched.
- All 11 new chapter links use the trailing-slash permalink form; no malformed links anywhere in the file.
- Front matter parses.

Reverse Gravity links to `dnd5e.wikidot.com`, matching Arcane Gate in the same list — I didn't invent a D&D Beyond magic-item ID for the Third Piece, since the First and Second use real ones I couldn't verify a counterpart for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)