### PR TITLE
Make the appendix pass part of writing a chapter

### DIFF
--- a/.claude/appendix-guide.md
+++ b/.claude/appendix-guide.md
@@ -1,0 +1,92 @@
+# Appendix guide
+
+How to update `_posts/2023-01-23-appendix.md` when a chapter is written. The appendix is the
+campaign's reference of record — who, what, where — and it goes stale silently, because nothing
+about writing a chapter forces you to open it.
+
+**Do this pass after the chapter file is finished and before opening the PR.** It is part of
+writing a chapter, not a separate chore.
+
+Companion files: `writing-voice.md` (how to write), `characters.md` (who they are),
+`story-so-far.md` (what happened), `to-do-list.md` (tracked fixes).
+
+## The pass
+
+1. **List every proper noun in the new chapter** — people, constructs, places, items, factions,
+   secrets. Include ones that only get a passing mention.
+2. **For each, grep the appendix.** `grep -n -i "name" _posts/2023-01-23-appendix.md`
+3. **Entry exists → append the chapter link** to its citation list. This is most of the work and
+   it is nearly always right; an entry that stops citing chapters looks abandoned.
+4. **No entry → decide.** Add one if the thing is named, recurs, or is load-bearing for a thread.
+   Skip walk-ons and scenery. A named NPC who speaks almost always earns an entry.
+5. **Ask whether anything changed category** — see below. This is the one that gets missed.
+6. **Check the Secrets section** if the chapter learned, resolved, or spent a secret.
+
+## Changed category — the trap
+
+The appendix files by *what a thing is*, and chapters can change that. The check is: **did this
+chapter reveal that an entry is filed under the wrong heading, or that it is now two things?**
+
+The worked example is **Landro**. It sat under **Objects** as "a monstrous colossus located in the
+Mournland" from ch. 77 to 83. Chapter 84 made that wrong twice: the colossus is destroyed, and
+Landro was never the colossus to begin with — *"The construct is not me either."* It became two
+entries, a **Character** (the mind, which joins the party) and an **Object** renamed
+**Landro (the colossus)** recording the destruction and pointing at the character.
+
+`to-do-list.md` tracks the same class of problem elsewhere: Davanor, K'ren, Chuck and Squiggy are
+people filed under *Foes, monsters, & creatures*, and Dolindar Family is a group filed under
+*Characters*. Don't add to that pile.
+
+## Sections, in file order
+
+`History` (Battles, Events) · `People` (Adventurers, Characters, Deities, Foes/monsters/creatures,
+Groups) · `Places` (Ships, Shops/inns/pubs, Landmarks/roads/trails, Towns/villages/cities) ·
+`Things` (Objects, Plants, Secrets)
+
+## Format rules
+
+Match the surrounding entries exactly. The ones that actually bite:
+
+- Bullet is `*` followed by **three spaces**. Continuation lines indent **four spaces**.
+- **Alphabetical by first name** within a section — Landro sits between Kycera and Lyra Swiftarrow,
+  Filch between Figaro and Flo.
+- Citations are `[[ch. N](/dnd/campaign/chapter-N/)]`, comma-separated, wrapped across lines.
+  **The trailing slash is mandatory** — without it the link 404s on the live site. Glaive's ch. 80
+  link was missing one for three chapters.
+- Sub-facts (item powers, a spent secret) are indented bullets under the parent entry.
+- Species, classes, and game terms are linked on first use, same targets as the chapters use.
+
+## Secrets
+
+The Secrets section records what the party has taken via the Vecna link. A secret has a life
+beyond being learned: it can be **resolved** in the story and later **spent** for a mechanical
+benefit. Record both, as indented bullets, and say how. `Mercy's Secret` is the model — learned in
+ch. 76, resolved in ch. 78, spent in ch. 84 to give Landro a memory.
+
+## Before committing
+
+```bash
+f=_posts/2023-01-23-appendix.md
+
+# every chapter link must end in a slash — this must print nothing
+grep -o "](/dnd/campaign/chapter-[0-9]*[^)]*)" $f | grep -v "/)$" | sort -u
+
+# alphabetical order within a section (edit the section name)
+python3 -c "
+import re; L=open('$f').read().split('\n')
+s=next(i for i,l in enumerate(L) if l.startswith('## Characters'))
+e=next(i for i,l in enumerate(L) if i>s and l.startswith('## '))
+n=[re.match(r'\*   \*\*(.+?)\*\*',l).group(1) for l in L[s:e] if re.match(r'\*   \*\*',l)]
+print([(a,b) for a,b in zip(n,n[1:]) if a.lower().lstrip('[')>b.lower().lstrip('[')] or 'ordered')
+"
+```
+
+Known pre-existing disorder: `Thistlewick Brandlestrum` before `Tella` in Characters. Leave it.
+
+## Don't fix silently
+
+`writing-voice.md` lists five appendix entries known to be wrong or stale — the swapped
+Eyes of the Star / Hand of the Wand descriptions, "Everwinter" for "Evernight", the Davanor entry,
+the Cindel species, and the seven links to unwritten chapters 53–55. Those are content decisions
+tracked in `to-do-list.md`, not drive-by corrections. Fixing an obviously broken *link* while
+you're in the file is fine; rewriting worldbuilding is not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,9 @@ They mix arc names (`eve-of-ruin`, `rod-of-seven-parts`), locations (`mournland`
 **Read `.claude/writing-voice.md` before drafting or editing any chapter prose.** It documents the
 voice in detail, derived from a full read of all 83 chapters, with examples. Alongside it:
 `.claude/characters.md` (what the party look like and how they carry themselves),
-`.claude/story-so-far.md` (arcs, character threads, what's still unresolved), and
-`.claude/to-do-list.md` (tracked fixes).
+`.claude/story-so-far.md` (arcs, character threads, what's still unresolved),
+`.claude/to-do-list.md` (tracked fixes), and `.claude/appendix-guide.md` (updating the appendix —
+see below).
 
 The short version: narrative prose, third person, **present tense** ("Mond hangs from a rung of the
 ladder…"), past tense only for things that already happened. Recent chapters run 2,000–4,600 words.
@@ -74,6 +75,21 @@ decided to." Dice outcomes are narrated as events, never as numbers in the prose
 distinct scenes).
 
 Links to D&D Beyond for monsters, spells, and rules are common and welcome.
+
+### Finishing a chapter means updating the appendix
+
+A chapter is not done when the prose is done. `_posts/2023-01-23-appendix.md` is the campaign's
+reference of record, and nothing about writing a chapter forces you to open it, so it goes stale
+silently.
+
+**After the chapter file is written and before opening the PR, do the appendix pass**: list the
+proper nouns the chapter introduces or touches, append the new chapter's link to every entry that
+already exists, add entries for anything named and load-bearing that has none, and check whether
+the chapter has moved something between sections — ch. 84 turned Landro from an Object into a
+Character and an Object. Record any secret learned, resolved, or spent.
+
+`.claude/appendix-guide.md` has the procedure, the format rules, and the checks to run before
+committing. Read it before editing the appendix.
 
 ### Session notes live in HTML comments
 


### PR DESCRIPTION
Chapter 84 exposed a gap in the process: the appendix goes stale silently. **Landro** sat under **Objects** as *"a monstrous colossus located in the Mournland"* from ch. 77 through 83, and ch. 84 revealed it was never the colossus at all — *"The construct is not me either."* Nothing about writing a chapter forces you to open the appendix, so nobody did.

This makes the appendix pass an explicit step in authoring a chapter.

## Two files, split by role

**`CLAUDE.md`** gets the trigger, as a new subsection under *Writing chapters*. That file is loaded every session, so the step gets seen rather than discovered. It says what the pass is and when it happens — after the chapter file is written, before the PR — and points at the guide.

**`.claude/appendix-guide.md`** (new) holds the procedure, so `CLAUDE.md` stays short. It becomes the fifth companion doc alongside `writing-voice.md`, `characters.md`, `story-so-far.md` and `to-do-list.md`, matching the existing one-doc-per-concern pattern.

## What the guide covers

- **The pass itself** — list the chapter's proper nouns, grep each against the appendix, append the chapter link where an entry exists, add entries for anything named and load-bearing that has none.
- **The changed-category trap**, with Landro as the worked example, and a pointer to the same class of problem `to-do-list.md` already tracks (Davanor, K'ren, Chuck and Squiggy filed under *Foes*; Dolindar Family under *Characters*).
- **Format rules that actually bite** — three spaces after the bullet, four-space continuation indent, alphabetical by first name, and the mandatory trailing slash on `[[ch. N](/dnd/campaign/chapter-N/)]`, which 404s without it.
- **Secrets have a life cycle** — learned, then resolved, then spent. `Mercy's Secret` is the model: ch. 76, ch. 78, ch. 84.
- **Two runnable checks** for before committing: one that finds malformed chapter links, one that verifies alphabetical order within a section. Both are verified working against the current file — the link check catches Glaive's ch. 80 link (fixed separately in #90), and the order check correctly reports only the pre-existing `Thistlewick` / `Tella` pair.
- **A don't-fix-silently note** — the five entries `writing-voice.md` flags as wrong or stale are content decisions tracked in `to-do-list.md`, not drive-by corrections.

No change to the appendix itself here; that's #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)