### PR TITLE
Give Bilwin the Sunburst Shield instead of a holy symbol

### DIFF
--- a/_posts/2026-03-02-chapter-73.md
+++ b/_posts/2026-03-02-chapter-73.md
@@ -3,7 +3,7 @@ title: "Chapter 73"
 show_date: true
 date: 2026-03-02T17:00:00-00:00
 sessiondate: "March 2, 2026"
-modified: 2026-03-02
+modified: 2026-08-19
 categories:
   - campaign
 tags:
@@ -182,7 +182,7 @@ and a [sheet of flames](https://www.dndbeyond.com/spells/2618946-burning-hands) 
 attack scorches its body, leaving mottled skin and blisters weeping a yellowish fluid.
 
 "Guess it's up to us now." Bilwin plants his feet solidly on the petrified floor and bangs his war hammer
-against his shield. A [deafening noise](https://www.dndbeyond.com/spells/2619017-shatter) fills
+against the Sunburst Shield. A [deafening noise](https://www.dndbeyond.com/spells/2619017-shatter) fills
 the cavern, originating underneath the creature's body. It pauses momentarily, the red eyes blink
 slowly, and it turns towards the dwarf and roars. As if in response to the outcry, the
 [floating beer stein](https://www.dndbeyond.com/spells/2263-spiritual-weapon) jiggles slightly

--- a/_posts/2026-05-04-chapter-78.md
+++ b/_posts/2026-05-04-chapter-78.md
@@ -3,7 +3,7 @@ title: "Chapter 78"
 show_date: true
 date: 2026-05-04T17:00:00-00:00
 sessiondate: "May 4, 2026"
-modified: 2026-05-04
+modified: 2026-08-19
 categories:
   - campaign
 tags:
@@ -34,7 +34,7 @@ Up close, the cave entrance is half-domed and warped, the rock around its openin
 The tunnel is ten to twenty feet wide and curves left before opening into a larger alcove that extends roughly twenty feet back into the rock. Half a dozen soldiers are scattered across the floor, their bodies perfectly preserved the way the Mournland keeps its dead — no decay, no smell, exactly as they fell. Their armor and swords lie close by, untouched by time, still faintly gleaming.
 
 The two look from one body to the next.
-Bilwin nods soberly, raises his holy symbol, and opens his mouth for what he intends as a proper moment of reverence. What comes out is a question and an accidental casting of [Speak with Dead](https://www.dndbeyond.com/spells/2619059-speak-with-dead) aimed at the nearest corpse. Whether Hanseath considers this a reasonable use of prayer or simply enjoys the chaos, it works. The soldier's body achieves a sort of groggy, reluctant awareness.
+Bilwin nods soberly, raises the Sunburst Shield, and opens his mouth for what he intends as a proper moment of reverence. What comes out is a question and an accidental casting of [Speak with Dead](https://www.dndbeyond.com/spells/2619059-speak-with-dead) aimed at the nearest corpse. Whether Hanseath considers this a reasonable use of prayer or simply enjoys the chaos, it works. The soldier's body achieves a sort of groggy, reluctant awareness.
 
 "Should we bury you?" Bilwin asks.
 

--- a/_posts/2026-08-03-chapter-84.md
+++ b/_posts/2026-08-03-chapter-84.md
@@ -3,7 +3,7 @@ title: "Chapter 84"
 show_date: true
 date: 2026-08-03T17:00:00-00:00
 sessiondate: "August 3, 2026"
-modified: 2026-08-03
+modified: 2026-08-19
 categories:
   - campaign
 tags:
@@ -65,7 +65,7 @@ For the rest of the day the companions hear intermittent muffled ribbits from so
 
 Before they leave the chamber, Bilwin goes to Glaive.
 
-The warforged lies where it fell, the polearm still in the ruin of its hand, the carved letters across its chest catching what little light there is. The dwarf had watched Gven crouch over the body the night before and had wanted to do it in his own way. He plants himself at the warforged's feet, sets his holy symbol against his palm, and gives it a warrior's last rites—the long dwarven form, the one for a soldier who died on their feet doing what they believed they were for. It isn't a short prayer. Only Gven understands the words, yet no one interrupts.
+The warforged lies where it fell, the polearm still in the ruin of its hand, the carved letters across its chest catching what little light there is. The dwarf had watched Gven crouch over the body the night before and had wanted to do it in his own way. He plants himself at the warforged's feet and gives it a warrior's last rites—the long dwarven form, the one for a soldier who died on their feet doing what they believed they were for. It isn't a short prayer. Only Gven understands the words, yet no one interrupts.
 
 Dolor waits until Bilwin finishes before raising the obvious problem.
 


### PR DESCRIPTION
Bilwin **has never carried a holy symbol in chapters 1–77**. The phrase entered at ch. 78 and appears in exactly two places, both Claude-drafted chapters:

| | |
|---|---|
| ch. 78 | "Bilwin nods soberly, raises his holy symbol…" |
| ch. 84 | "sets his holy symbol against his palm" |

Everywhere else in the campaign, "holy symbol" refers to *someone else's, as an object* — the medallions in Davanor's warehouse (ch. 25, 28), B'raq's symbol, The One's scorched-over symbol (ch. 40, 44).

It also sits badly against the worldbuilding. Ch. 25:

> Bilwin realizes that they're holy symbols—and are highly illegal since the Conflict.

His own line there is "These are holy symbols! Like clerics used to wear over their robes." Past tense.

## What he does have

The **Sunburst Shield**, bought off an inebriated dwarf in a Bluelake market in ch. 63 — a shield Hanseath revealed to him, and named:

> The Bearded One drank a beer with it, sang a rousin' tune, and then called it the Sunburst Shield.

Until this PR it was **named exactly once in the whole campaign and never referred to again**. Ch. 73 has him bang a war hammer against "his shield" without calling it anything.

## Changes

- **ch. 73** — "bangs his war hammer against his shield" → "against the Sunburst Shield"
- **ch. 78** — raises the Sunburst Shield over the dead Cyran soldiers instead of a holy symbol. The accidental *Speak with Dead* that follows is unchanged.
- **ch. 84** — drops the holy symbol clause from Glaive's last rites; he plants himself at the warforged's feet and gives the rites.
- `modified` bumped to 2026-08-19 on all three, per the convention in `CLAUDE.md`.

Prose only — no comments, choreography, or tags touched.

## Not in this PR

- **There is no Sunburst Shield entry in the appendix**, and after this it's named in three chapters. Adding one is a content decision, so it's left for you.
- The ch. 85 draft still says "holy symbol" twice; that carries into its second draft, not here.
- The `.claude/npc-characters.md` work is a separate concern and stays out of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)