### PR TITLE
Add npc-characters.md, starting with the three archmages

### DIFF
--- a/.claude/npc-characters.md
+++ b/.claude/npc-characters.md
@@ -1,0 +1,331 @@
+# NPC characters
+
+Traits, personality, mannerisms, and speaking habits for named NPCs, so a returning NPC sounds
+like themselves. `characters.md` covers the five player characters plus Xantic and Landro; this
+file covers everyone else.
+
+Companion files: `writing-voice.md` for how to write them, `story-so-far.md` for what happened,
+`characters.md` for the party, `to-do-list.md` for tracked fixes. The appendix
+(`_posts/2023-01-23-appendix.md`) is the index of *who and what*; this file is *how they sound*.
+
+**Everything here is derived from the chapters and quoted verbatim.** Where the appendix and the
+chapters disagree, the chapters win and it says so.
+
+## The rule this file exists to serve
+
+From `writing-voice.md`: *"Give every new NPC one rule like this and hold it for every line they
+speak."* That file already carries the one-line register for 25 NPCs — Gertrude's three-word
+sentences, Redbud's `...one ...word ...at ...a ...time`, 404's error messages, Tham's phonetic
+Scots. Those stay there as the quick-reference table.
+
+**This file is for NPCs who recur enough to need more than one line**: the ones with a history, a
+relationship to another NPC, an agenda, and a physical presence that has to stay consistent across
+a dozen chapters. Start here, then check the table in `writing-voice.md` for anyone not yet
+built out.
+
+---
+
+## At a glance
+
+| | Species / role | Home | First seen | Chapters |
+|---|---|---|---|---|
+| **Alustriel Silverhand** | Human wizard, high mage of Silverymoon | The Sanctum, in Sigil | ch. 55 (unwritten) | 63, 64, 66, 67, 68, 74, 75 |
+| **Tasha** | Human archmage, of Oerth | — | ch. 64 | 64, 67, 68, 74, 75 |
+| **Mordenkainen** | Human archmage, of Oerth | Oerth | ch. 63 | 63, 64, 67, 68, 74, 84 |
+| **Malaina van Talstiv** | Human assassin; Alustriel's wife | The Sanctum | ch. 67 | 67, 68, 74 |
+
+The three archmages cast *Wish* together to negate Vecna's power and got five adventurers instead
+(ch. 64). That accident is the reason for every scene any of them are in. **Alustriel is the host
+and the chair**; the Sanctum is her house, she sets the agenda and closes the meetings. **Tasha
+undercuts Mordenkainen**, constantly and with enjoyment. **Mordenkainen does not notice.**
+
+---
+
+## Alustriel Silverhand
+
+**Female human wizard · high mage of Silverymoon · married to Malaina van Talstiv**
+
+- **Hair** long silver. **Eyes** sparkling blue. Tall, slender, statuesque; sits and moves
+  gracefully.
+- **Clothing** light blue robes in ch. 63; by ch. 74, "a stunning gown that seems to flow
+  majestically even when she's sitting still."
+- **Carries** a thin, dark wooden staff topped with a
+  [unicorn's head](https://forgottenrealms.fandom.com/wiki/Staff_of_Silverymoon) — the Staff of
+  Silverymoon (ch. 63).
+- **Drinks** red wine from a bowl-shaped glass. A carafe floats to her, tips, pours, and lowers
+  itself onto a side table. She swirls it and watches the legs glide down the inside of the glass.
+  This piece of business is hers and recurs.
+- **Epithets in use:** "the silver-haired mage", "the silvery mage", "the otherworldly resplendent
+  mage", "Lady Alustriel."
+
+**Voice rule — the composed host.** Two registers and she switches cleanly between them:
+*long, ordered, lyrical* when she's explaining a world, and *clipped imperatives* when she's
+directing people. She never raises her voice. Because of that, the single most useful thing
+available with her is what happens on the rare occasion she does.
+
+**Her rhetorical tic is paired opposites in short parallel clauses.** On the Astral Plane, ch. 67:
+
+> "It's a beautiful place. A dangerous place. It's peaceful. It's maddening."
+
+The imperative register, in full:
+
+> "You were summoned accidentally. Come to the parlor. I need a drink." *(ch. 64 — her first line
+> to the party; she then turns and leaves "neither beckoning nor waiting for them to follow")*
+
+> "Come now, let's not tarry in this unpleasant place." *(ch. 66, through the portal)*
+
+> "This will do. Sit." *(ch. 74)*
+
+> "Go, sit with the first piece of the rod and meditate. It will guide you." *(ch. 67)*
+
+**She addresses people by role, warmly**: "my dear dwarf," "master dwarf," "young sorcerer," "sir
+dwarf." Her farewell is a formula: *"Farewell and may courage be your constant companion."*
+
+**She is self-aware about her own verbosity** — "make my best attempt to be laconic" — and then
+delivers four hundred words on Vecna anyway.
+
+**She is diplomatic in a way that has an edge underneath it.** Introducing her colleagues in
+ch. 64: *"Tasha is,"* — a pause — *"also a skilled practicioner. And, of course, Mordenkainen."*
+Tasha catches it and snickers; "the depths of her eyes show a more volatile reaction."
+
+**She manages Mordenkainen out loud.** *"Later, Mordenkainen. We have to figure what to do since
+our spell failed."*
+
+**She declines Gven without heat and without wavering.** This has happened at least three times
+and the answer never changes shape: she is courteous, she is immovable, and she is a little
+amused. Ch. 64, when Gven puts a hand on her thigh, she covers it with her own, firmly moves it
+off, and says *"Nice to meet you. I'll introduce you to my wife later."* Ch. 74: *"While we are
+flattered, we must decline."*
+
+**She is careful with people, and it costs her.** The memory session with Bilwin in ch. 74 is the
+key scene: she offers it, sits with him, guides it, and stops it when it starts to hurt him —
+*"We must move onward. Those memories are too painful for you to handle."* Malaina sits in
+specifically "to make certain she doesn't strain herself, or endanger you both," and at the end
+Malaina is holding her up.
+
+**She names the campaign's thesis** at the end of ch. 67, and it's the most important thing she
+has ever said:
+
+> "It's not your physical strength… It's the bond of friendship that so obviously holds you
+> together… Friendship holds a power that Vecna does not understand. A power that can be his
+> downfall."
+
+She follows it with an out: *"None of you should continue, unless you are certain this is the path
+for you."* She always offers the out.
+
+**What she knows and hands over:** Lolth (ch. 64), Vecna's history and Kas's betrayal (ch. 67),
+Eberron / Khorvaire / the Day of Mourning / the warforged / the colossi and their docents (ch. 74),
+the hertilod's vulnerability to lightning (ch. 74). She is the party's exposition source of record.
+She opens and closes every portal, and gave Dolor the
+[sending stone](https://www.dndbeyond.com/magic-items/9180147-sending-stones) that summons one.
+
+## Tasha
+
+**Female human archmage, of Oerth · also known as Iggwilv, Natasha, and Zybilna**
+
+- **Hair** raven, cascading past starkly white shoulders. Sleeveless dress that barely goes past
+  the knee. Legs crossed.
+- **Where she is in any given scene:** reclining. A chaise lounge in ch. 64, 67, and 74; a divan
+  surrounded by plush cushions in ch. 75. She is essentially never standing when a scene opens,
+  and her standing up is an event.
+- **Holds** a very large wine glass, or a leather tome. She tips the glass in acknowledgement
+  rather than speaking, when speaking isn't worth it.
+- **Exits** by turning quickly so her robes twirl around her (ch. 74).
+- **Epithets in use:** "the ravishing dark-haired wizard", "the raven-haired Tasha", "the mage".
+  Mordenkainen addresses her as "my dear enchantress"; nobody else does.
+
+**Voice rule — arch and camp on the surface, absolute on the substance.** Every line has a
+performance in it. When the performance stops, somebody is about to have a very bad time.
+Her typography is *one italicised word per line* for emphasis:
+
+> "Speak for yourself, darling. Some of us are _always_ fabulous." *(ch. 64)*
+
+> "You needn't think about it quite _that_ much. In fact, not at all." *(ch. 75)*
+
+**She needles, and Alustriel is her favourite target.** In ch. 64, watching Gven size Alustriel up:
+*"Besides, that one appears to be exactly your type. Perhaps there was no mistake."* Alustriel
+"throws a harsh look at the other mage, but doesn't verbalize any disagreement."
+
+**Her enthusiasm for cruelty is played straight, not as a joke.** Mordenkainen proposes she babysit
+the banished Vecna — "Tasha can—nay, exuberantly wants to—keep an eye on him" — and "Tasha's smile
+turns decidedly malicious."
+
+**The goldfish is the definitive Tasha scene (ch. 74) and the one to reach back to.** Gven
+propositions her once too often. Tasha smiles, points toward Gven's chambers, walks her there in
+silence, and lets her get into the bath. Gven becomes a goldfish. Tasha lets her panic, scoops her
+into a glass, sets it on the table, and asks:
+
+> "Are you done being a nuisance to those who are trying to help you? Are you going to be polite
+> now?"
+
+Gven bobs yes. Tasha nods her acceptance — **and then pours the glass out onto the tile floor and
+watches her asphyxiate to death** before restoring her. Then she stares into Gven's eyes long
+enough to be certain the message landed, and leaves without another word.
+
+That scene establishes the rule: **she extracts the agreement first and administers the lesson
+anyway.** Gven has not forgotten it, and the joke is now live — the ch. 85 draft has Tasha saying "I am
+not the one in this room with the memory of a goldfish."
+
+**She is genuinely kind when it costs her nothing**, which is what makes the rest work. Ch. 75,
+Grindlefoot asks her to scry his garden:
+
+> "Ah, my petite yet sturdy comrade, it would be my pleasure."
+
+It's "the first time her smile seemed sincere." She then makes him think very hard about a potato
+purely to keep him occupied, and admits it.
+
+**She offers Bilwin help nobody asked her for**, in ch. 67, and takes no for an answer:
+
+> "If you want to remember, let me in." … "You are not ready yet. When you are, I can help."
+
+Note that Alustriel is the one who eventually does it, in ch. 74. **Tasha's offer is still open.**
+
+**She calls people by an affectionate diminutive that is also slightly at their expense**:
+"darling," "my petite yet sturdy comrade." **She notices who isn't in the room**: "Where's the
+halfing, Grindlefoot?" closes ch. 74.
+
+**She warns before she acts.** Ch. 74, before any of it: *"You know, she can do things to you from
+the inside out that will make you wish for death"* — said about Alustriel, to steer Gven off. Gven
+propositioned Tasha instead. The warning was accurate about the wrong wizard.
+
+## Mordenkainen
+
+**Male human archmage, of [Oerth](https://forgottenrealms.fandom.com/wiki/Oerth)**
+
+- **Bald head, closely-trimmed beard, penetrating eyes** — "he looks like a hawk searching for
+  prey" (ch. 64), "a bald man with a hawk-like face" (ch. 63).
+- **Clothing** grey high-collared robes with red velvet trim; **medium-sized gold hoops in each
+  ear**; a deep burgundy hat with a tasseled tip (ch. 74). His robes stream out behind him when he
+  moves, which he arranges.
+- **Voice** deep and melodic. Stated outright in ch. 64.
+- **Drinks brown liquor over ice**, twirled around the cube — not the wine everyone else is having
+  (ch. 74). This distinguishes him at a glance in a room of wine glasses.
+- **Sits in a leather easy chair, reading**. Ch. 84: reading *four books at once*, one in his hands
+  and three standing open around him, their pages turning at the same moment.
+
+**Voice rule — exclamation and condescension in the same breath.** He answers questions nobody
+asked, claims foresight he didn't have, and is generous in a way that keeps himself the largest
+thing in the room. Every offer of help is also a demonstration.
+
+> "Let's not be rude, Alustriel. I'm sure our guests would enjoy some refreshments." *(ch. 64 —
+> correcting his host, as courtesy)*
+
+> "Fascinating! We shall have to discuss this further so I can learn more."
+
+> "My dear enchantress, that too has been solved by my foresight."
+
+> "Indeed! I have thought of that as well."
+
+> "I know just the place! Ready? Of course you are. You're ready when I'm ready. let's go!"
+> *(ch. 74 — and he is through the portal before Mond can get out of his chair)*
+
+> "Please extend your hospitality to my young associates as though they were almost me."
+> *(ch. 74, to Thoom. The "almost" is the entire character.)*
+
+**He expects to be recognised, and is wounded when he isn't.** Ch. 64, on being introduced:
+
+> He turns his head slightly to the side, showing them his favorite profile, and flutters his eyes.
+> When they don't respond, he turns back to them with a glare that silently screams, "You should
+> know who I am or it is to your own peril."
+
+**He is an empiricist to the point of vandalism.** Handed the first piece of the rod over dinner in
+ch. 67, he turns it over, says "I feel its energy emanating, as though the pulse of a living being,"
+and then **smashes it on the table**. The companions are astonished; Tasha and Alustriel are
+unmoved, which tells you this is normal. His explanation, "speaking to no one in particular": *"I
+had to verify it's authenticity."* **He does not explain himself to people, only near them.**
+
+**Bad news arrives from him with impatience attached.** Ch. 74: "Mordenkainen irritatingly adds,
+'Teleportation and divination work poorly there, to say the least. We won't be able to place you
+close to the rod. You'll be on your own to find it.'"
+
+**He has a private rage about Vecna that has never been explained, and shouldn't be resolved
+casually.** Ch. 67, while Alustriel recounts Vecna's history: "A glance at Mordenkainen reveals a
+look of pure anger and Dolor wonders what that might mean. Hatred for their enemy, certainly. But
+why?" And then, quietly, later in the same scene:
+
+> "We do not stand idly by. We watch Vecna and slow him in other ways, unseen to you, others, and
+> even himself."
+
+That is the only time in eight chapters he speaks quietly. **Open thread.**
+
+**By ch. 84 he has acquired a second register: dry and minimal, where the smaller the reaction the
+bigger it is.** He doesn't look up from his four books to congratulate them — *"Well done," he says. "Quite good
+of you."* He taps Landro's crystal twice to test it, is told not to, and:
+
+> Mordenkainen's eyebrows go up half an inch, which for him is falling out of the chair.
+
+Then he "allows that he will let the household know the adventurers are hungry and would like to
+rest," without any visible change of expression. **This register is the funniest thing available
+with him and it works because the ch. 64 version was so loud.**
+
+**What he supplies:** the [Chime of Exile](https://dnd5e.wikidot.com/wondrous-items:chime-of-exile)
+and the whole plan (ch. 64), the intelligence on where each piece is, and access — he is known and
+welcomed at Thoom's House of Boom, and the bazaar crowd magically parts for him as he walks.
+
+## Malaina van Talstiv
+
+**Female human assassin · Alustriel's wife · runs the Sanctum**
+
+Not an archmage, and the entire point of her. She "manage[s] all of the non-magical aspects of this
+manor" and says so on introduction.
+
+- **Clothing** a flowing blouse under a navy vest, fitted pants, and leather pauldrons and braces
+  (ch. 74).
+- **Armed, visibly and otherwise:** "a handful of visible knives — and several more hidden from
+  view, but easily accessible."
+- **Moves silently.** She arrives in a room without anyone hearing her, twice.
+
+**Voice rule — hospitality delivered as a checklist, by someone wearing knives.** Her tic is the
+piled-up list, and she is completely unbothered by being the only non-magical person in a house of
+archmages.
+
+> "Thank the stars! Are you alright? Anyone stabbed, poked, sliced, ensorceled, or suffering from
+> any other sort of ailment?" *(ch. 67, her first line)*
+
+> "I never know which one of these things is magical." *(hesitantly touching a lamp, which then
+> lights and hovers)*
+
+> "There is coffee, freshly squeezed juice — natural, not magical — and plenty of scintillating
+> choices for you to consider." *(ch. 68, and she winks at Gven on the last clause)*
+
+**She is protective of Alustriel and it is the only thing that makes her serious.** She attends the
+memory session in ch. 74 uninvited, explains herself in one sentence — "This can be taxing for her
+and I'm here to make certain she doesn't strain herself, or endanger you both" — and is holding
+Alustriel up by the end of it.
+
+**She is amused by Gven rather than threatened by her**, which is the correct read and is worth
+keeping consistent.
+
+---
+
+## Appendix gaps for these four
+
+Recorded here rather than fixed, per the standing rule in `to-do-list.md` that appendix changes are
+content decisions. Tracked as item 3, *Missing and wrong chapter citations*, in that file:
+
+- **Alustriel's entry omits ch. 66 and 68.** It reads "known for being intelligent, wise,
+  charismatic, and very beautiful," which is a stat block, not a person.
+- **Tasha's entry omits ch. 68**, and doesn't mention that she is the one who will keep Vecna
+  after the Chime of Exile — the reason she is in the campaign at all.
+- **Mordenkainen's entry omits ch. 68, and cites ch. 75, where he does not appear at all.**
+- **Malaina's entry omits ch. 68.**
+- **The Sanctum's entry omits ch. 66, 67, and 75.** It also links a real-world blog post as the
+  source for the house, which is fine but worth knowing.
+- Ch. 74's prose links the name *Mordenkainen* to Alustriel's wiki page. A copy-paste slip.
+
+## Still to build out
+
+NPCs who recur and have a register recorded in `writing-voice.md` but no entry here yet. Highest
+value first, by how likely they are to come back:
+
+- **Fenseck** (a.k.a. Dave Chevits) — Dolor's patron, appears in ch. 47 in disguise and ch. 68 in a
+  vision. Live thread, will return.
+- **Mercy, Justice, Charity, Pious, 404, and Filch** — the warforged pilgrims of Ialos. Owed a debt.
+- **Hanseath** — Bilwin's god; ch. 29, 31, 32, 75. The rules-breaking drunk.
+- **Gustaf Mondalbrot** — ch. 42–52, the mapmaker. Whereabouts currently unaddressed.
+- **Veylara** — the storm giant. **Tempest Edge is still hers**; this reunion is owed.
+- **Torp / Davanor** — alive, hunting his sister across planes.
+- **Eva Brightbroom**, **Gertrude**, **Ikasa**, **Redbud**, **Captain Inda**, **Tham**,
+  **Cap'n Don Karnahge**, **Cindel Trueshot**, **Umberto Noblin**, **Sarcelle Malinosh**.
+- **The Grimoire of Gastronomy** — new in ch. 85; a talking magic item, which the campaign already
+  has three of (Whelm, Wave, Blackrazor). Add once ch. 85 is final.

--- a/.claude/to-do-list.md
+++ b/.claude/to-do-list.md
@@ -110,6 +110,65 @@ if a future chapter trusted them.
 - [ ] "praticioners" → practitioners (Eyes of the Star entry)
 - [ ] "proprieter" → proprietor (Boscoe); "penchance" → penchant (Dave Chevits)
 
+### Missing and wrong chapter citations — the archmages
+
+**The Sanctum cast are the most under-cited entries in the appendix.** All four NPCs appear in
+chapters their entries don't list, and one entry cites a chapter its subject isn't in. Verified by
+grepping the rendered prose of every chapter with HTML comments stripped, so passing mentions count
+(per `appendix-guide.md` step 1) but working notes don't.
+
+| Entry | Section | Appears in | Currently cited | **Add** | **Remove** |
+|---|---|---|---|---|---|
+| **Alustriel Silverhand** | Characters | 63, 64, 66, 67, 68, 74, 75 | 55, 63, 64, 67, 74, 75 | **66, 68** | — |
+| **Tasha** | Characters | 64, 67, 68, 74, 75 | 64, 67, 74, 75 | **68** | — |
+| **Mordenkainen** | Characters | 63, 64, 67, 68, 74, 84 | 63, 64, 67, 74, 75, 84 | **68** | **75** |
+| **Malaina van Talstiv** | Characters | 67, 68, 74 | 67, 74 | **68** | — |
+| **The Sanctum** | Shops, inns, & pubs | 64, 66, 67, 74, 75, 84 | 64, 74, 84 | **66, 67, 75** | — |
+
+- [ ] **Alustriel Silverhand — add ch. 66 and 68.** Ch. 66: her voice comes through the portal,
+      *"Come now, let's not tarry in this unpleasant place."* Ch. 68: she breakfasts with the party
+      and opens the portal to the Astral Plane.
+- [ ] **Tasha — add ch. 68.** She is named at the morning meal and is present when the archmages
+      see the party off.
+- [ ] **Mordenkainen — add ch. 68**, where he is at the meal and the send-off.
+- [ ] **Mordenkainen — remove ch. 75.** He is not in that chapter. `grep -ci mordenkainen` on
+      `_posts/2026-03-30-chapter-75.md` returns **0**. The archmage in ch. 75 is Tasha, with the
+      potato-scrying scene, and she is already cited for it.
+- [ ] **Malaina van Talstiv — add ch. 68.** *"followed shortly by Malaina's silent entrance"*, and
+      she is named again in the list of who accompanies the morning meal.
+- [ ] **The Sanctum — add ch. 66, 67, and 75.** Ch. 66 returns there through the portal, ch. 67 is
+      the baths-and-dinner chapter set entirely inside it, ch. 75 opens with Grindlefoot wandering
+      its halls.
+
+**Ch. 85 will add all three archmages again** (Alustriel, Tasha, Mordenkainen — not Malaina, who
+isn't in it) plus the Sanctum's kitchen. Do that in ch. 85's own appendix pass, not here.
+
+**Not part of this item:** Alustriel's ch. 55 citation is one of the seven links to unwritten
+chapters, tracked in item 2. Leave it until that decision is made.
+
+**While you're in these entries**, the descriptions are thin — Alustriel's reads "known for being
+intelligent, wise, charismatic, and very beautiful," which is a stat block rather than a person,
+and Tasha's doesn't mention that she is the one who will keep Vecna after the Chime of Exile, which
+is her whole reason for being in the campaign. `npc-characters.md` has the material for both.
+
+- [ ] Ch. 74's prose links the name *Mordenkainen* to **Alustriel's** wiki page. Copy-paste slip in
+      the chapter, not the appendix, but it surfaced during the same pass.
+
+### Missing entries
+
+- [ ] **The Sunburst Shield has no appendix entry**, and is now named in three chapters. Bilwin
+      buys it in ch. 63 from an inebriated dwarf in a Bluelake market, and it is Hanseath's:
+      *"The Bearded One drank a beer with it, sang a rousin' tune, and then called it the Sunburst
+      Shield."* PR #93 named it in ch. 73 and ch. 78 as well, replacing the holy symbol that had
+      crept into the drafted chapters. Belongs under **Objects**, immediately before Tempest Edge
+      (nothing else in that section falls between S and T). Stated mechanics, for the sub-bullet: *"It can shine a light as bright
+      as daylight once a day for ten minutes and the undead really don't like it."* Cite ch. 63, 73,
+      and 78.
+
+Same class as the paid-for-but-never-written items in section 2 — a thing that exists in the
+fiction and is invisible in the reference. Worth a sweep for others: any item acquired on the page
+that hasn't been named since.
+
 ### Structural
 
 - [ ] 15 entries carry no chapter citation while the rest do: Elar, Herbert, Lyra Swiftarrow, Preva,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ They mix arc names (`eve-of-ruin`, `rod-of-seven-parts`), locations (`mournland`
 **Read `.claude/writing-voice.md` before drafting or editing any chapter prose.** It documents the
 voice in detail, derived from a full read of all 83 chapters, with examples. Alongside it:
 `.claude/characters.md` (what the party look like and how they carry themselves),
+`.claude/npc-characters.md` (the same for recurring NPCs — traits, mannerisms, and the speaking
+rule that holds for every line they say),
 `.claude/story-so-far.md` (arcs, character threads, what's still unresolved),
 `.claude/to-do-list.md` (tracked fixes), and `.claude/appendix-guide.md` (updating the appendix —
 see below).
@@ -92,10 +94,13 @@ Character and an Object. Record any secret learned, resolved, or spent.
 committing. Read it before editing the appendix.
 
 **The same staleness applies to the `.claude/` reference docs.** A chapter that introduces a
-companion, resolves a thread, or settles a question about a character leaves `characters.md` and
-`story-so-far.md` wrong until someone updates them, and nothing forces that either. Ch. 84 alone
-added Landro, closed Dolor's class question, and moved three open threads. Update them in the same
-pass, and bump the coverage line at the top of `story-so-far.md`.
+companion, resolves a thread, or settles a question about a character leaves `characters.md`,
+`npc-characters.md`, and `story-so-far.md` wrong until someone updates them, and nothing forces
+that either. Ch. 84 alone added Landro, closed Dolor's class question, and moved three open
+threads. Update them in the same pass, and bump the coverage line at the top of `story-so-far.md`.
+
+An NPC who gets a second scene needs an entry in `npc-characters.md`, not just an appendix line —
+the appendix records who they are, that file records how they sound.
 
 ### Session notes live in HTML comments
 


### PR DESCRIPTION
Nothing in `.claude/` recorded **how a recurring NPC sounds**. `writing-voice.md` carries a one-line register for 25 of them — Gertrude's three-word sentences, Redbud's `...one ...word ...at ...a ...time`, 404's error messages — which is right for a walk-on and not enough for someone with a history, a relationship to another NPC, an agenda, and a dozen chapters of physical continuity.

## `.claude/npc-characters.md` (new)

Alustriel, Tasha, Mordenkainen, and Malaina van Talstiv, built from every scene they appear in — ch. 63, 64, 66, 67, 68, 74, 75, 84 — plus their appendix entries. Each gets appearance, mannerisms, relationships, what they supply to the plot, and a stated voice rule:

- **Alustriel** — *the composed host.* Long lyrical exposition when explaining a world, clipped imperatives when directing people ("This will do. Sit."). Rhetorical tic is paired opposites in short parallel clauses: *"It's peaceful. It's maddening."*
- **Tasha** — *arch and camp on the surface, absolute on the substance.* Always reclining; one italicised word per line. The goldfish scene gives her rule: **she extracts the agreement first and administers the lesson anyway.**
- **Mordenkainen** — *exclamation and condescension in the same breath.* Smashes artifacts on tables to verify them and explains himself "to no one in particular." Two threads flagged: his unexplained rage about Vecna (ch. 67), and the dry minimal register he acquires in ch. 84.
- **Malaina** — *hospitality delivered as a checklist, by someone wearing knives.* Included because she is in every one of these scenes and inseparable from Alustriel.

Every quote checked verbatim against the corpus by script. Also carries the appendix gaps for these four, and a "still to build out" list ordered by likelihood of return — Fenseck, the Ialos pilgrims, Hanseath, Veylara, Torp.

## `.claude/to-do-list.md`

**Archmage citation gaps.** All four appear in chapters their entries don't list; ch. 68 is the common miss.

| Entry | Add | Remove |
|---|---|---|
| Alustriel Silverhand | 66, 68 | — |
| Tasha | 68 | — |
| Mordenkainen | 68 | **75** |
| Malaina van Talstiv | 68 | — |
| The Sanctum | 66, 67, 75 | — |

Mordenkainen's ch. 75 citation is wrong — `grep -ci` on that chapter returns **0**. The archmage in ch. 75 is Tasha, with the potato-scrying scene, and she is already cited for it.

**Missing Sunburst Shield entry**, now named in three chapters after #93, with the description, stated mechanics, and alphabetical position ready to paste.

Both verified by script over rendered prose with HTML comments stripped, so passing mentions count (per `appendix-guide.md` step 1) but working notes don't.

## `CLAUDE.md`

Picks up the new file in the reference-doc list and in the staleness rule, with a line noting that an NPC who gets a second scene needs an entry here, not just an appendix line — the appendix records who they are, this records how they sound.

Docs only; no chapters or appendix touched. Appendix edits are left as content decisions, tracked rather than applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)