### PR TITLE
Record what chapter 85 taught us about matching the voice

### DIFF
--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -160,9 +160,31 @@ for harming. He has it silvered and carved with plant filigree in ch. 63.
 |---|---|---|
 | Wooden Gruumsh amulet | before ch. 1 | Carved by her father. **Given to Veylara in ch. 32** — she no longer wears it |
 | Plain greatsword | before ch. 1 | Nondescript, non-magical, ~5 feet, scabbard across her back |
-| **Tempest Edge** | ch. 32 | Veylara's gift. Lightning once/day as a bonus action; lightning resistance; on a crit, a deafening thunderclap |
+| **Two small hand axes** | before ch. 1 | One at her side, one in her pack. Thrown or used in the off hand |
+| **Two javelins** | before ch. 1 | Carried on her back, for distance. Rarely mentioned — see below |
+| **Tempest Edge** | ch. 32 | Veylara's gift. **5½ feet long**, so it does *not* out-reach her height. Lightning once/day as a bonus action; lightning resistance; on a crit, a deafening thunderclap |
 | **Vestment of the Bound Sigil** | **ch. 55** | See below |
 | **Boots of Striding and Springing** | ch. 63 | Bought on-page from a gnome cordwainer |
+
+**The hand axes and javelins are hers from the start and are easy to forget.** Both predate ch. 1 and
+both are load-bearing in a fight — the axes are what she reaches for when the greatsword is wrong for
+the job, and the javelins are her only real answer at range.
+
+- **Hand axes.** Ch. 7 has her pull "a handaxe from her belt" and throw it. Ch. 13 is explicit about
+  the count: she "readies her two hand axes for short range throws." One rides at her side, the other
+  in her pack.
+- **Javelins.** Two, carried on her back — ch. 62, "a javelin strapped to her back"; ch. 66, she pulls
+  one and then "the remaining javelin from her back"; ch. 73, "her second and only remaining javelin."
+  **Ch. 13 says four**, thrown during the first wave at Wayside. Two is the number from ch. 62 on.
+
+**Don't narrate the javelins except when she uses one.** Carrying javelins around is not simple and
+the prose doesn't pretend otherwise — they surface at the moment of the throw and are otherwise
+invisible. Same restraint the chapters already show.
+
+**Tempest Edge is 5½ feet and Gven is 6′8″, so the blade is shorter than she is.** Noted here because
+the sword that is "longer than Gven is tall" in ch. 31 is **Veylara's own greatsword**, handed over for
+Gven to admire a chapter before the boot dagger is given. Ch. 32 is the authority: "the giant's five
+and a half foot long dagger."
 
 The longcoat is the "shimmering longcoat" and "enchanted coat" the later chapters keep referring to
 from ch. 59 onward. Note the scabbard moves: across her back early, at her hip by ch. 77.

--- a/.claude/style-check.py
+++ b/.claude/style-check.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Measure a chapter draft against Tod's voice in chapters 1-77.
+
+    python3 .claude/style-check.py path/to/draft.md        # from the repo root
+
+Reports the structural metrics in writing-voice.md under "Structure — the four things
+that give a draft away", plus the contraction check. Baselines are computed live from
+_posts/, so they stay true as the corpus grows.
+"""
+import re, sys, glob, statistics as st
+
+DIALOGUE_VERBS = r'(?:says|asks|responds|replies|exclaims|adds|offers|explains|observes|notes|agrees|tells|continues)'
+
+def clean(t):
+    t = re.sub(r'^---\n.*?\n---\n', '', t, flags=re.S)   # front matter
+    t = re.sub(r'<!--.*?-->', '', t, flags=re.S)         # HTML comments (working notes)
+    t = re.sub(r'!\[[^\]]*\]\([^)]*\)', '', t)           # images
+    return re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', t)    # links -> label
+
+def words(s):  return re.findall(r"[A-Za-z][A-Za-z'’-]*", s)
+def sents(s):  return [x for x in re.split(r'(?<=[.!?])\s+', re.sub(r'[ \t]+', ' ', s)) if words(x)]
+
+def paras(t):
+    return [p.strip() for p in re.split(r'\n\s*\n', t)
+            if p.strip() and p.strip() != '---' and not p.strip().startswith('#')]
+
+FRONTED = re.compile(
+    r'^(?:[A-Z][a-z]+ing\b|Having\b|Seeing\b|Knowing\b|Standing\b|Noting\b|Realizing\b|Hearing\b'
+    r'|Looking\b|Turning\b|Reaching\b|Holding\b|Moving\b|Walking\b|Taking\b|Feeling\b|Wondering\b'
+    r'|Presuming\b|Surprised\b|Unable\b|Freed\b|With [a-z]+[^,]{0,40},|After [^,]{0,40},'
+    r'|Before [^,]{0,40},|From [a-z][^,]{0,40},)[^.]{0,80},')
+
+def measure(files):
+    t = "\n\n".join(clean(open(f).read()) for f in files)
+    P = paras(t)
+    narr_p = [p for p in P if not p.lstrip().startswith('"')]
+    all_s  = sents(re.sub(r'\n+', ' ', t))
+    narr   = re.sub(r'"[^"]*"', ' ', t)                    # narration = outside quotes
+    narr_s = sents(re.sub(r'\n+', ' ', narr))
+    nsl    = [len(words(s)) for s in narr_s]
+    npl    = [len(words(p)) for p in narr_p]
+    turns  = [len(words(m)) for m in re.findall(r'"([^"]*)"', t) if words(m)]
+    one    = sum(1 for p in narr_p if len(sents(p)) == 1)
+    nw     = len(words(narr))
+    contr  = len(re.findall(r"\b\w+['’](s|t|re|ve|ll|d|m)\b", narr))
+    expand = sum(len(re.findall(r'\b' + f + r'\b', narr, re.I)) for f in
+                 ['it is','does not','that is','they are','there is','he is','is not',
+                  'are not','cannot','did not'])
+    return {
+        'words'        : len(words(t)),
+        'fronted/100'  : 100 * sum(1 for s in all_s if FRONTED.match(s)) / max(len(all_s), 1),
+        'para mean'    : st.mean(npl), 'para med': st.median(npl),
+        '1-sent para%' : 100 * one / max(len(narr_p), 1),
+        'sent mean'    : st.mean(nsl), 'sent med': st.median(nsl),
+        'sent <=6w%'   : 100 * sum(1 for x in nsl if x <= 6) / len(nsl),
+        'speech mean'  : st.mean(turns) if turns else 0,
+        'collective/1k': 1000 * len(re.findall(r'\b(the companions|the group|the adventurers|the party)\b', t, re.I)) / max(len(words(t)), 1),
+        'lead-in tags' : len(re.findall(r'\b\w+ ' + DIALOGUE_VERBS + r'[,:]\s*"', t, re.I)),
+        'trailing tags': len(re.findall(r'"[^"]*,"\s+(?:the\s+\w+\s+)?\w+ ' + DIALOGUE_VERBS + r'\b', t, re.I)),
+        'contract/1k'  : 1000 * contr / max(nw, 1),
+        'expanded/10k' : 10000 * expand / max(nw, 1),
+    }
+
+def corpus(lo, hi):
+    out = []
+    for n in range(lo, hi + 1):
+        out += [f for f in glob.glob('_posts/*chapter-%d.md' % n) if '-ai' not in f]
+    return out
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+    base = corpus(56, 77)
+    if not base:
+        sys.exit("No _posts/ found — run this from the repo root.")
+    tod, draft = measure(base), measure([sys.argv[1]])
+    print("%-16s %>10s %>10s" .replace('>','') % ('metric', 'you 56-77', 'draft'))
+    print("-" * 40)
+    for k in tod:
+        a, b = tod[k], draft[k]
+        fmt = "%-16s %10.1f %10.1f" if isinstance(a, float) else "%-16s %10d %10d"
+        print(fmt % (k, a, b))
+    print("\nTargets: fronted/100 ~9.7 | para mean ~53 | 1-sent para% ~19 | sent mean ~17"
+          "\n         sent <=6w% ~9 | contract/1k ~17 (never below 12) | expanded/10k <15")

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -94,6 +94,114 @@ So a chapter that is one long corridor of rooms and fights will come in low, and
 is not to force dialogue into a dungeon chapter — it's to make sure a dungeon run is broken up by a
 Sarcelle, an Umberto, or a Tham.
 
+## Structure — the four things that give a draft away
+
+**Added after chapter 85.** Everything above measures word choice. These measure *shape*, and they
+turned out to matter more: a draft can pass every tic check above and still not read like you,
+because the sentences and paragraphs are built differently. Measured over all 74 of your chapters
+1–77 (excluding the AI-alternate ch. 62), with ch. 56–77 broken out as the most recent run written
+by you alone.
+
+`.claude/style-check.py` computes all of these. Run it from the repo root before handing over a
+draft.
+
+All figures below are what `style-check.py` prints, so the file and the tool never disagree.
+
+| | You, 1–77 | You, 56–77 | Drafted 78–84 | Ch. 85 draft 1 | Ch. 85 rev 3 |
+|---|---|---|---|---|---|
+| Fronted-participle openers, per 100 sentences | 9.2 | **10.1** | 1.9 | **0.0** | 7.7 |
+| Narration paragraph, mean words | 57.4 | **53.0** | 38.8 | 29.3 | 49.8 |
+| Narration paragraph, median words | 51 | **46** | 34 | 24 | 45 |
+| Single-sentence narration paragraphs | 18.1% | **19.4%** | 30.7% | 39.5% | 14.3% |
+| Narration sentence, mean words | 17.4 | **17.8** | 15.0 | 14.7 | 17.1 |
+| Narration sentence, median | 17 | **18** | 13 | 11 | 15 |
+| Narration sentences ≤ 6 words | 11.8% | **9.1%** | 22.3% | 27.4% | 19.7% |
+| Average quoted speech turn, words | 44.4 | **29.3** | 6.9 | 5.2 | 14.3 |
+| Collective nouns per 1k words | 3.6 | **2.8** | 2.7 | 0.6 | 1.8 |
+| Dialogue tags: lead-in vs trailing | 105 : 20 | **32 : 6** | 2 : 35 | 1 : 5 | 3 : 11 |
+| Contractions per 1k narration words | 21.4 | **19.9** | 18.6 | 21.9 | 16.4 |
+| Written-out forms per 10k narration words | 8.7 | **9.1** | 20.0 | 76.9 | 7.7 |
+
+### 1. Fronted participial openers — your signature, and the easiest thing to miss
+
+You open sentences with a fronted participial or absolute phrase **10 times per 100 sentences**.
+The drafted run does it twice. Chapter 85's first draft did it **zero times in 4,500 words**,
+and that single fact did more to make it not sound like you than every vocabulary tic combined.
+
+It is densest in combat, where it is close to the default sentence shape. One paragraph after
+another in ch. 66:
+
+> **Gripping his battle axe,** Bilwin follows Gven into battle.
+
+> **With the others engaged in close combat,** Dolor draws Gleaming Blade and joins them.
+
+> **Having gotten its attention,** the huge spider turns towards Gertrude and spews a stream of acid.
+
+> **Taking its fury out on Bilwin,** the beast lashes out with two of its legs.
+
+> **Seeing the spider dragon close to its end,** Gven grips Tempest Edge tightly with both hands.
+
+> **No longer paralyzed,** Grindlefoot sits on the floor recovering his strength.
+
+Write combat this way by default. The construction carries the reason for the action into the same
+sentence as the action, which is why your fights read as decisions rather than as a list of turns.
+
+### 2. Paragraphs, and the single-sentence paragraph as punctuation
+
+Your narration paragraphs run **53 words on average, median 46** — four to seven sentences. The
+drafted run halves that, and chapter 85's first draft halved it again.
+
+The single-sentence paragraph is a real device of yours and it is listed under **Voice** below as
+one. But you use it at **19.4%** of narration paragraphs. The drafted run uses it at 37%, and
+ch. 85's first draft at 40% — twice your rate. Past about one in five it stops being punctuation
+and becomes the default rhythm, and the prose reads clipped and modern instead of like you.
+
+### 3. Your characters make speeches
+
+Average length of a quoted turn: **29.3 words in ch. 56–77, 44.4 across 1–77.** Chapter 85's first
+draft averaged **5.2** — rapid-fire one-liners with nobody holding the floor. Compare Grindlefoot
+asking Tasha for a favour in ch. 75: four sentences, 55 words, one paragraph, one speaker.
+
+The median turn is only 11 words, so this is a *distribution*, not a floor. Keep the punchlines
+short. Let the expository and character turns run long — an NPC explaining a thing, a character
+reasoning a puzzle out aloud, anyone with an agenda.
+
+### 4. Telepathy is in quotes, never italics
+
+Every instance in chapters 1–77 uses plain double quotes with a narrative tag doing the work:
+
+> each of them hears in their head simultaneously, "Wazzup?" *(ch. 64, Maltok)*
+
+> Whelm, is speaking to him telepathically. "Come on lad, let's get 'em!" *(ch. 51)*
+
+> the sorcerer sends the telepathic message, "Stop attacking." *(ch. 70)*
+
+> All of the companions hear the creature's telepathic response, "Your arcane tricks do not work on
+> me, sorcerer." *(ch. 70)*
+
+**Ch. 84 sets Landro in italics and is the only chapter that does**, which makes it a drafted-run
+import rather than a habit of yours. See *The drafted chapters invent props* — same class of
+problem, applied to typography.
+
+### Also
+
+- **Tag dialogue before it, not after.** 104 lead-in tags against 19 trailing across 1–77 —
+  `Bilwin exclaims, "We get that a lot!"`. Your other habit is an action beat before the line with
+  no tag at all. A trailing `"…," he says` is the drafted run's default, not yours.
+- **Collective nouns.** "The companions," "the group," "the adventurers" — 2.8 to 3.6 per 1,000
+  words. Drafts run a fraction of that and name everyone individually instead.
+
+### The trap: these targets pull against the contraction rule
+
+Chapter 85's third pass fixed the structure and **broke the narration voice doing it**. Lengthening
+and formalising sentences dropped contractions to 9.5 per 1,000 narration words and pushed
+written-out forms to 74.6 per 10,000 — chapter 84's exact failure, reintroduced by fixing something
+else. "It is on everything." "There is breakfast." "That is as far as she gets."
+
+**Measure both, in the same pass.** Fixing the shape is not finished until the contractions are back
+where they were. Note that Landro is exempt and unaffected, because his uncontracted register lives
+inside quotation marks and the contraction rule is measured on narration only.
+
 ## Yours vs. Claude's
 
 Measured across the full 151,865-word pre-Claude corpus (chapters 1–77) against the drafted run.
@@ -555,7 +663,10 @@ only account of it.
 - **Gleaming Blade** is looted off a goblin corpse in ch. 7 and mistaken for a rusty old sword;
   Dolor attunes to it in ch. 9 and learns it belonged to a paladin.
 - **Tempest Edge** is a *gift* from **Veylara**, a storm giant, in ch. 32 — it is her boot dagger,
-  sister-forged to her own greatsword, and it is longer than Gven is tall. **This debt is still
+  sister-forged to her own greatsword, and it is **five and a half feet long**, which is shorter
+  than Gven. (The sword that is "longer than Gven is tall" in ch. 31 is Veylara's *own*
+  greatsword, handed over to be admired a chapter before the dagger is given. An earlier draft of
+  this file conflated the two and a ch. 85 draft repeated the error.) **This debt is still
   open.** Gven promised to return the blade one day, and Veylara holds her family's Gruumsh
   medallion — carved by Gven's father — as the counter-gift, worn as an earring. Any scene that
   wants to land on Gven should know this exists.


### PR DESCRIPTION
Chapter 85's first draft passed **every** tic check in `writing-voice.md` — zero spaced em dashes, zero "the way a…" similes, contractions on target — and still didn't read like your prose. Profiling all 74 chapters of 1–77 against it found why: **the divergence was structural, not lexical.**

## `writing-voice.md` — new "Structure" section

| | You, 56–77 | Drafted 78–84 | Ch. 85 draft 1 | Ch. 85 rev 3 |
|---|---|---|---|---|
| Fronted-participle openers /100 sentences | **10.1** | 1.9 | **0.0** | 7.7 |
| Narration paragraph, mean words | **53.0** | 38.8 | 29.3 | 49.8 |
| Single-sentence narration paragraphs | **19.4%** | 30.7% | 39.5% | 14.3% |
| Average quoted speech turn | **29.3** | 6.9 | 5.2 | 14.3 |
| Dialogue tags, lead-in : trailing | **32 : 6** | 2 : 35 | 1 : 5 | 3 : 11 |

**1. Fronted participial openers** are close to your default sentence shape in combat, and the drafted run doesn't use them. One paragraph after another in ch. 66: *"Gripping his battle axe, Bilwin follows Gven into battle." / "Having gotten its attention, the huge spider turns towards Gertrude." / "Seeing the spider dragon close to its end, Gven grips Tempest Edge."*

**2. Paragraphs.** Yours run 53 words, median 46. The single-sentence paragraph is a genuine device of yours — but at 19%, not 40%. Past about one in five it stops being punctuation and becomes the rhythm.

**3. Your characters make speeches.** 29 words per turn against the draft's 5.

**4. Telepathy is in plain quotes with a narrative tag, never italics** — four citations from ch. 51, 64, 70. Ch. 84 is the only chapter using italics, and it's drafted, so it's an import rather than a habit. Cross-referenced to the "drafted chapters invent props" section from #94 — same class of problem, applied to typography.

**The trap, recorded:** fixing the structure *broke* the contraction rule, reintroducing chapter 84's exact failure (9.5 contractions/1k, 74.6 written-out forms/10k). Lengthening and formalising sentences does that. Both have to be measured in the same pass.

## `.claude/style-check.py` (new)

```
python3 .claude/style-check.py path/to/draft.md
```

Computes every figure in that section, with baselines read live from `_posts/` so the doc and the tool can't drift apart. Run against ch. 84 it correctly flags it as off-target (fronted 1.7 vs 10.1, paragraphs 28.9 vs 53.0).

**Drop this file if you'd rather not have a script in the repo** — the section stands on its own without it.

## `characters.md`

- **Gven's two hand axes and two javelins**, cited from ch. 7, 13, 62, 66, 73, with your rule written down: the javelins are only narrated when she uses one, because carrying javelins around isn't simple.
- **Tempest Edge is 5½ feet**, so it's shorter than she is. Both files now record that the sword "longer than Gven is tall" in ch. 31 is **Veylara's own greatsword**, handed over to be admired a chapter before the boot dagger is given. `writing-voice.md` had conflated the two, which is where a ch. 85 draft got it wrong.

## Notes

- Deliberately placed away from #94's insertion point in the same file, so the two merge cleanly in either order. #94 and #95 remain independent.
- Docs and tooling only — no chapters touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)