### PR TITLE
Add chapter 85 and its reference updates

### DIFF
--- a/.claude/appendix-guide.md
+++ b/.claude/appendix-guide.md
@@ -7,8 +7,9 @@ about writing a chapter forces you to open it.
 **Do this pass after the chapter file is finished and before opening the PR.** It is part of
 writing a chapter, not a separate chore.
 
-Companion files: `writing-voice.md` (how to write), `characters.md` (who they are),
-`story-so-far.md` (what happened), `to-do-list.md` (tracked fixes).
+Companion files: `writing-voice.md` (how to write), `characters.md` (the party),
+`npc-characters.md` (how recurring NPCs sound), `story-so-far.md` (what happened),
+`to-do-list.md` (tracked fixes).
 
 ## The pass
 
@@ -18,9 +19,39 @@ Companion files: `writing-voice.md` (how to write), `characters.md` (who they ar
 3. **Entry exists → append the chapter link** to its citation list. This is most of the work and
    it is nearly always right; an entry that stops citing chapters looks abandoned.
 4. **No entry → decide.** Add one if the thing is named, recurs, or is load-bearing for a thread.
-   Skip walk-ons and scenery. A named NPC who speaks almost always earns an entry.
+   Skip walk-ons and scenery. A named NPC who speaks almost always earns an entry. Keep it to one or
+   two sentences — see *An entry says what a thing is* below.
 5. **Ask whether anything changed category** — see below. This is the one that gets missed.
 6. **Check the Secrets section** if the chapter learned, resolved, or spent a secret.
+
+## An entry says what a thing *is*, not what happened to it
+
+**The most common mistake in this pass, and the easiest one to make while the chapter is fresh.**
+The appendix is an index. What happened belongs in `story-so-far.md`; how somebody sounds belongs in
+`npc-characters.md`; the entry here is the short, flat statement of what the thing is, plus its
+chapter links.
+
+Every entry Tod cut from the chapter 85 pass was an entry that had drifted into narrative:
+
+| Written | Should have been |
+|---|---|
+| "It has baths, guest rooms, a library, a solarium, and a kitchen the companions never find until ch. 85" | *(nothing — The Sanctum's existing description was fine)* |
+| "The pilot's helmet taken from Landro is left with them on the way out of Mournland" | *(nothing — that is a plot event, and it lives in `story-so-far.md`)* |
+| The Grimoire's five ingredients and the order Dolor deduced | *(nothing — the puzzle and its solution are the chapter's, not the index's)* |
+| "The Sanctum is her home and she is the one who opens and closes every portal. Unfailingly composed." | *(nothing — that is characterisation, and it lives in `npc-characters.md`)* |
+
+**So: when an existing entry is already accurate, the pass adds a chapter link and nothing else.**
+Resist improving the description while you are in there. If the description is genuinely wrong or
+stale, that is a content decision — track it in `to-do-list.md` rather than rewriting it in passing,
+the same as the five known-wrong entries listed under *Don't fix silently*.
+
+**New entries get one or two sentences.** Look at what is already there and match its register:
+
+> **Batter golem** - A humanoid creature of pale golden batter that rises out of the mixing cauldron
+> when a legendary confection is prepared.
+
+Mechanics are the one thing that earns a sub-bullet, because the appendix is where the party's item
+powers are recorded — see Tempest Edge, Whelm, and the Sunburst Shield. Plot is never a sub-bullet.
 
 ## Changed category — the trap
 
@@ -77,11 +108,16 @@ import re; L=open('$f').read().split('\n')
 s=next(i for i,l in enumerate(L) if l.startswith('## Characters'))
 e=next(i for i,l in enumerate(L) if i>s and l.startswith('## '))
 n=[re.match(r'\*   \*\*(.+?)\*\*',l).group(1) for l in L[s:e] if re.match(r'\*   \*\*',l)]
-print([(a,b) for a,b in zip(n,n[1:]) if a.lower().lstrip('[')>b.lower().lstrip('[')] or 'ordered')
+k=lambda x: re.sub(r'^(the|a|an) ','',re.sub(r'^\[','',x).lower())
+print([(a,b) for a,b in zip(n,n[1:]) if k(a)>k(b)] or 'ordered')
 "
 ```
 
-Known pre-existing disorder: `Thistlewick Brandlestrum` before `Tella` in Characters. Leave it.
+Names sort past a leading `The` — `The Sanctum` sits under S, `The Grimoire of Gastronomy` under G.
+
+Known pre-existing disorder, all of it fine to leave: `Thistlewick Brandlestrum` before `Tella` in
+Characters; `Grinder's Mill` before `Gilded Glyph` and `Scribbles & Nibs` before `The Fizz Hutt` in
+Shops; `Other Trail` before `The Broken Heart` in Landmarks.
 
 ## Don't fix silently
 

--- a/.claude/npc-characters.md
+++ b/.claude/npc-characters.md
@@ -29,9 +29,9 @@ built out.
 
 | | Species / role | Home | First seen | Chapters |
 |---|---|---|---|---|
-| **Alustriel Silverhand** | Human wizard, high mage of Silverymoon | The Sanctum, in Sigil | ch. 55 (unwritten) | 63, 64, 66, 67, 68, 74, 75 |
-| **Tasha** | Human archmage, of Oerth | — | ch. 64 | 64, 67, 68, 74, 75 |
-| **Mordenkainen** | Human archmage, of Oerth | Oerth | ch. 63 | 63, 64, 67, 68, 74, 84 |
+| **Alustriel Silverhand** | Human wizard, high mage of Silverymoon | The Sanctum, in Sigil | ch. 55 (unwritten) | 63, 64, 66, 67, 68, 74, 75, 85 |
+| **Tasha** | Human archmage, of Oerth | — | ch. 64 | 64, 67, 68, 74, 75, 85 |
+| **Mordenkainen** | Human archmage, of Oerth | Oerth | ch. 63 | 63, 64, 67, 68, 74, 84, 85 |
 | **Malaina van Talstiv** | Human assassin; Alustriel's wife | The Sanctum | ch. 67 | 67, 68, 74 |
 
 The three archmages cast *Wish* together to negate Vecna's power and got five adventurers instead
@@ -300,8 +300,7 @@ keeping consistent.
 
 ## Appendix gaps for these four
 
-Recorded here rather than fixed, per the standing rule in `to-do-list.md` that appendix changes are
-content decisions. Tracked as item 3, *Missing and wrong chapter citations*, in that file:
+**Resolved in the chapter 85 appendix pass.** Kept here as the record of what was wrong:
 
 - **Alustriel's entry omits ch. 66 and 68.** It reads "known for being intelligent, wise,
   charismatic, and very beautiful," which is a stat block, not a person.
@@ -312,6 +311,37 @@ content decisions. Tracked as item 3, *Missing and wrong chapter citations*, in 
 - **The Sanctum's entry omits ch. 66, 67, and 75.** It also links a real-world blog post as the
   source for the house, which is fine but worth knowing.
 - Ch. 74's prose links the name *Mordenkainen* to Alustriel's wiki page. A copy-paste slip.
+
+## The Grimoire of Gastronomy
+
+**Sentient cookbook · the Sanctum's kitchen · ch. 85**
+
+The campaign's fourth talking magic item, after Whelm, Wave and Blackrazor, and the first that isn't
+a weapon. Enormous, bound in leather gone dark at the corners, its title stamped across the cover in
+gold. It flies on beating pages, settles in the air at about eye height, and opens itself to a
+requested page — hard, so the pages slap flat.
+
+**Voice rule — every line comes back to its own injury or its own dignity.** It is the wounded party
+in any room it is in, and it will tell you so. That is the whole character and it holds for every
+line it speaks.
+
+> "Oh, thank the gods. People. Functional people, with hands, who did not spend the morning
+> explaining to me that they had read me already."
+
+> "I would like everyone present to note which of us in this room he thought to put inside the
+> bubble, and which of us he left on the table next to an open flame."
+
+> "Would you like one of your arms burnt off? No? Then perhaps some sympathy."
+
+> "The warnings come at the end."
+
+Its second register is professional exasperation at people who don't read properly — *"This is
+exactly the sort of thing people never read carefully, and then they are disappointed, and then it
+is somehow my doing."* When the recipe finally works it abandons the grievance completely and
+shrieks with joy from the ceiling.
+
+It cannot be argued with about cooking and it is right about cooking, which is the reason it gets
+away with the rest.
 
 ## Still to build out
 
@@ -327,5 +357,3 @@ value first, by how likely they are to come back:
 - **Torp / Davanor** — alive, hunting his sister across planes.
 - **Eva Brightbroom**, **Gertrude**, **Ikasa**, **Redbud**, **Captain Inda**, **Tham**,
   **Cap'n Don Karnahge**, **Cindel Trueshot**, **Umberto Noblin**, **Sarcelle Malinosh**.
-- **The Grimoire of Gastronomy** — new in ch. 85; a talking magic item, which the campaign already
-  has three of (Whelm, Wave, Blackrazor). Add once ch. 85 is final.

--- a/.claude/story-so-far.md
+++ b/.claude/story-so-far.md
@@ -4,7 +4,7 @@ Storylines and character arcs, for use when drafting or revising. The appendix
 (`_posts/2023-01-23-appendix.md`) is the reference index — who, what, where. This is the shape of
 the story: what each arc was about, what changed for each character, and what was left open.
 
-**Coverage: chapters 1–84**, the complete campaign, read in full and cross-checked against the
+**Coverage: chapters 1–85**, the complete campaign, read in full and cross-checked against the
 appendix.
 
 Note that **chapters 53–55 do not exist as posts** — they were sessions that never got written up.
@@ -232,7 +232,7 @@ Then the kiln flares, the world goes dark, and they're standing in a stranger's 
 
 > "Well, fuck."
 
-## Arc VI — The Rod of Seven Parts (ch. 64–84)
+## Arc VI — The Rod of Seven Parts (ch. 64–85)
 
 **They were summoned by accident.** Three archmages — **Alustriel Silverhand**, **Mordenkainen**, and
 **Tasha** — cast *Wish* to negate Vecna's power and got five adventurers instead. Mordenkainen's
@@ -306,6 +306,28 @@ any of them have seen in the Mournland.
 
 They return through the obsidian portal to the Sanctum with **three of seven pieces**, and advance
 to **level 13**.
+
+**Ch. 85 is the exhale, and the campaign's first comic chapter since Elsemar.** Two days at the
+Sanctum with nothing to do, which none of them are good at. Landro narrates the furniture. Gven
+cleans her sword and lies awake thinking about Torp, because he turns up whenever her hands are
+empty. Bilwin doesn't sleep at all, still working on *"You came back."* Mond admits to himself he
+doesn't want to go home. **The helmet is settled off-page**: they left it at Ialos on the way out,
+which closes the ch. 82 debt, and Landro reveals it knew the dead pilot — "He was not good at his
+work. He was, however, present, which the others were not."
+
+Then the kitchen. Mordenkainen, attempting a legendary confection out of **the Grimoire of
+Gastronomy**, casts a *globe of invulnerability* around himself so the flour won't land on his
+robes, and seals all three archmages inside it at the moment the recipe fails. The oven's heat rune
+is cracked and the only way to stop it is to finish the recipe. The three of them disagree about the
+ingredient order from inside the bubble, immaculate, while the kitchen is white with flour; Dolor
+reasons out the one order that satisfies all three constraints — flour, egg, sugar, salt, ash — and
+the mixture rises into a **batter golem**. The room cracks along a rune at the same moment, and while
+the others fight the golem Dolor re-carves the rune with his thieves' tools. The golem dies on fire,
+keeps swelling from the heat, and fills the kitchen with cake around all nine of them.
+
+No piece of the rod, no level, and no direction for the fourth piece yet. What it does is give the
+party a day of ordinary life among people who are no longer strangers, and let Tasha refer out loud
+to the goldfish.
 
 ---
 
@@ -418,7 +440,7 @@ own small argument that he intends to stay.
 a child's doll before anyone can stop him, knocks himself out on a table and sleeps through the
 Battle of Wayside. Leaves to protect Wayside. Has his own character post.
 
-## Threads left open at ch. 84
+## Threads left open at ch. 85
 
 **Live and load-bearing:**
 
@@ -449,10 +471,10 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
 
 **Owed, promised, or simply left:**
 
-- **The pilot's helmet** from Landro, still promised to the warforged pilgrims of Ialos. **The
-  gemstone promised alongside it in ch. 82 is now Landro's vessel** and is not theirs to give — Gven
-  raised it, and Dolor's answer was "they get the helmet." The debt is half paid at best, and Ialos
-  has not been told.
+- ~~**The pilot's helmet** from Landro, promised to the warforged pilgrims of Ialos.~~ **Closed in
+  ch. 85** — they left it with the pilgrims on the way out of Mournland, and Charity accepted it. It
+  is inert now that the pilot's chamber is destroyed. The gemstone promised alongside it in ch. 82
+  stays with the party as Landro's vessel.
 - **Mercy and Filch**, returned to Ialos. **Gertrude**, last seen swinging a greatclub into fifteen
   cultists. **Ikasa** wants to find Palenna; the appendix says Palenna was rescued.
 - **Eva Brightbroom** is keeping five houses and a garden in Neverwinter and does not explain

--- a/.claude/to-do-list.md
+++ b/.claude/to-do-list.md
@@ -125,23 +125,29 @@ grepping the rendered prose of every chapter with HTML comments stripped, so pas
 | **Malaina van Talstiv** | Characters | 67, 68, 74 | 67, 74 | **68** | — |
 | **The Sanctum** | Shops, inns, & pubs | 64, 66, 67, 74, 75, 84 | 64, 74, 84 | **66, 67, 75** | — |
 
-- [ ] **Alustriel Silverhand — add ch. 66 and 68.** Ch. 66: her voice comes through the portal,
+- [x] ~~**Alustriel Silverhand — add ch. 66 and 68.**~~  **Done** in the ch. 85 appendix pass.
+       Ch. 66: her voice comes through the portal,
       *"Come now, let's not tarry in this unpleasant place."* Ch. 68: she breakfasts with the party
       and opens the portal to the Astral Plane.
-- [ ] **Tasha — add ch. 68.** She is named at the morning meal and is present when the archmages
+- [x] ~~**Tasha — add ch. 68.**~~  **Done** in the ch. 85 appendix pass.
+       She is named at the morning meal and is present when the archmages
       see the party off.
-- [ ] **Mordenkainen — add ch. 68**, where he is at the meal and the send-off.
-- [ ] **Mordenkainen — remove ch. 75.** He is not in that chapter. `grep -ci mordenkainen` on
+- [x] ~~**Mordenkainen — add ch. 68**~~  **Done** in the ch. 85 appendix pass.
+      , where he is at the meal and the send-off.
+- [x] ~~**Mordenkainen — remove ch. 75.**~~  **Done** in the ch. 85 appendix pass.
+       He is not in that chapter. `grep -ci mordenkainen` on
       `_posts/2026-03-30-chapter-75.md` returns **0**. The archmage in ch. 75 is Tasha, with the
       potato-scrying scene, and she is already cited for it.
-- [ ] **Malaina van Talstiv — add ch. 68.** *"followed shortly by Malaina's silent entrance"*, and
+- [x] ~~**Malaina van Talstiv — add ch. 68.**~~  **Done** in the ch. 85 appendix pass.
+       *"followed shortly by Malaina's silent entrance"*, and
       she is named again in the list of who accompanies the morning meal.
-- [ ] **The Sanctum — add ch. 66, 67, and 75.** Ch. 66 returns there through the portal, ch. 67 is
+- [x] ~~**The Sanctum — add ch. 66, 67, and 75.**~~  **Done** in the ch. 85 appendix pass.
+       Ch. 66 returns there through the portal, ch. 67 is
       the baths-and-dinner chapter set entirely inside it, ch. 75 opens with Grindlefoot wandering
       its halls.
 
-**Ch. 85 will add all three archmages again** (Alustriel, Tasha, Mordenkainen — not Malaina, who
-isn't in it) plus the Sanctum's kitchen. Do that in ch. 85's own appendix pass, not here.
+**Done.** Ch. 85's own appendix pass added the three archmages, Landro, the Sanctum, Sigil and Ialos,
+and created entries for the Grimoire of Gastronomy, the batter golem and the Sunburst Shield.
 
 **Not part of this item:** Alustriel's ch. 55 citation is one of the seven links to unwritten
 chapters, tracked in item 2. Leave it until that decision is made.
@@ -156,7 +162,8 @@ is her whole reason for being in the campaign. `npc-characters.md` has the mater
 
 ### Missing entries
 
-- [ ] **The Sunburst Shield has no appendix entry**, and is now named in three chapters. Bilwin
+- [x] ~~**The Sunburst Shield has no appendix entry**~~  **Done** in the ch. 85 appendix pass.
+      , and is now named in three chapters. Bilwin
       buys it in ch. 63 from an inebriated dwarf in a Bluelake market, and it is Hanseath's:
       *"The Bearded One drank a beer with it, sang a rousin' tune, and then called it the Sunburst
       Shield."* PR #93 named it in ch. 73 and ch. 78 as well, replacing the holy symbol that had

--- a/_posts/2023-01-23-appendix.md
+++ b/_posts/2023-01-23-appendix.md
@@ -55,8 +55,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     [Mournland](https://eberron.fandom.com/wiki/Mournland); with Mercy, Justice, Pious, and Charity.
     [[ch. 76](/dnd/campaign/chapter-76/)]
 *   **Alustriel Silverhand** - [Female human wizard](https://forgottenrealms.fandom.com/wiki/Alustriel_Silverhand)
-    and high mage of Silverymoon, married to Malaina van Talstiv. The Sanctum is her home and she is
-    the one who opens and closes every portal for the adventurers. Unfailingly composed.
+    known for being intelligent, wise, charismatic, and very beautiful.
     [[ch. 55](/dnd/campaign/chapter-55/), [ch. 63](/dnd/campaign/chapter-63/), [ch. 64](/dnd/campaign/chapter-64/),
     [ch. 66](/dnd/campaign/chapter-66/), [ch. 67](/dnd/campaign/chapter-67/), [ch. 68](/dnd/campaign/chapter-68/),
     [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/), [ch. 85](/dnd/campaign/chapter-85/)]
@@ -139,7 +138,6 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **Landro** - The intelligence built to pilot the colossus of the same name, and the only thing aboard
     it to survive whatever went wrong. Alone in [Mournland](https://eberron.fandom.com/wiki/Mournland) since
     the war, it joins the adventurers by transferring to a crystal that is affixed to Mond's staff.
-    It speaks telepathically to the whole group and narrates whatever it has not seen before.
     [[ch. 84](/dnd/campaign/chapter-84/), [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Lyra Swiftarrow** - Female half-elven ranger who lives in the forest east of Wayside.
 *   **Lysan** - Female [Githyanki](https://forgottenrealms.fandom.com/wiki/Githyanki) crew member on the
@@ -149,8 +147,8 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **Magnus** - Male human nobleman member of the Low Elves in Wayside. [[ch. 2](/dnd/campaign/chapter-2/),
     [ch. 3](/dnd/campaign/chapter-3/)]
 *   **[Malaina van Talstiv](https://5e.tools/bestiary/malaina-van-talstiv-veor.html)** - Female human assassin
-    and wife of Alustriel Silverhand, who manages every non-magical aspect of the Sanctum.
-    [[ch. 67](/dnd/campaign/chapter-67/), [ch. 68](/dnd/campaign/chapter-68/), [ch. 74](/dnd/campaign/chapter-74/)]
+    and wife of Alustriel Silverhand. [[ch. 67](/dnd/campaign/chapter-67/),
+    [ch. 68](/dnd/campaign/chapter-68/), [ch. 74](/dnd/campaign/chapter-74/)]
 *   **Marigold** - Female half-elf hostess & server at Dolly's Donuts in Elsemar. [[ch. 18](/dnd/campaign/chapter-18/)]
 *   **Mercy** - A [warforged](https://dnd5e.wikidot.com/lineage:warforged) pilgrim in
     [Mournland](https://eberron.fandom.com/wiki/Mournland); leader of the pilgrims, including Justice, Pious, Charity, and 404.
@@ -184,7 +182,6 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     [ch. 6](/dnd/campaign/chapter-6/)]
 *   **Tasha** - [Female human archmage](https://forgottenrealms.fandom.com/wiki/Iggwilv) from the world
     of [Oerth](https://forgottenrealms.fandom.com/wiki/Oerth). Also known as Iggwilv, Natasha, or Zybilna.
-    Once Vecna is banished with the Chime of Exile, she is the one who will keep watch over him.
     [[ch. 64](/dnd/campaign/chapter-64/), [ch. 67](/dnd/campaign/chapter-67/), [ch. 68](/dnd/campaign/chapter-68/),
     [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/), [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Thistlewick Brandlestrum** - Male gnome owner of The Fizz Hutt, a kombucha shop in Elsemar.
@@ -241,12 +238,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 ## Foes, monsters, & creatures
 
 *   **Batter golem** - A humanoid creature of pale golden batter that rises out of the mixing cauldron
-    when the Grimoire of Gastronomy's legendary confection is prepared correctly. It stands as tall as
-    Gven and half again as broad, with a dent where a face would be, and it speaks thickly enough to be
-    understood. Blades stick in it and vines slide off it; fire works.
-    [[ch. 85](/dnd/campaign/chapter-85/)]
-    *   It sprays batter over a fifteen-foot radius, turning the ground into difficult terrain.
-    *   Killed by fire, it keeps swelling from the heat and fills whatever room it died in.
+    when a legendary confection is prepared incorrectly. [[ch. 85](/dnd/campaign/chapter-85/)]
 *   **Chimera** - The adventurers first significant challenge, where they slayed a
     [chimera](https://forgottenrealms.fandom.com/wiki/Chimera) that was troubling one
     of Ben's many fields in the area. After this conquest, the group began calling
@@ -363,8 +355,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **The Four Corners** - A cartography shop in the Scrivener's Ward of Elsemar, owned by Whichway.
     [[ch. 23](/dnd/campaign/chapter-23/)]
 *   **The Sanctum** - One of [Alustriel Silverhand's homes](https://steampunkapotamus.wordpress.com/2024/06/29/sanctum/)
-    located in Sigil, it is where she and the other mages bring the adventurers. It has baths, guest
-    rooms, a library, a solarium, and a kitchen the companions never find until ch. 85.
+    located in Sigil, it is where she and the other mages bring the adventurers.
     [[ch. 64](/dnd/campaign/chapter-64/), [ch. 66](/dnd/campaign/chapter-66/), [ch. 67](/dnd/campaign/chapter-67/),
     [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/), [ch. 84](/dnd/campaign/chapter-84/),
     [ch. 85](/dnd/campaign/chapter-85/)]
@@ -427,8 +418,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **Everwinter** - The mirror city of Neverwinter in the Shadowfell plane. [[ch. 59](/dnd/campaign/chapter-59/), [ch. 60](/dnd/campaign/chapter-60/)]
 *   **Ialos** - Community of [warforged](https://dnd5e.wikidot.com/lineage:warforged) pilgrims in
     [Mournland](https://eberron.fandom.com/wiki/Mournland), a village abandoned after
-    the Day of Mourning. The pilot's helmet taken from Landro is left with them on the way out of
-    Mournland. [[ch. 76](/dnd/campaign/chapter-76/), [ch. 77](/dnd/campaign/chapter-77/),
+    the Day of Mourning. [[ch. 76](/dnd/campaign/chapter-76/), [ch. 77](/dnd/campaign/chapter-77/),
     [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Mirganor** - The primary city on the east coast of Eritz, accessible by The Ha-derech.
     Before **The Conflict**, Mirganor was the center of the arcane orders, where the leaders lived,
@@ -483,15 +473,8 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
         (rolling a natural 20) it emits a radiant glow where the target must roll a constitution saving
         throw or become blinded until their next turn.
 *   **The Grimoire of Gastronomy** - An enormous sentient cookbook kept in the Sanctum's kitchen, bound
-    in leather gone dark at the corners with its title stamped in gold. It flies, opens itself to a
-    requested page, and complains without pause. Mordenkainen was attempting a legendary confection from
-    its two hundred and fortieth page when the recipe failed, taking the page with it.
+    in leather gone dark at the corners with its title stamped in gold.
     [[ch. 85](/dnd/campaign/chapter-85/)]
-    *   The five ingredients of the confection are Starlight Flour, a Dragon's Egg (a common name for a
-        large egg, and not from a dragon), Wintersheen Sugar, Void Salt, and Phoenix Ash. Added in the
-        wrong order the flour detonates; added correctly the mixture rises into a batter golem.
-    *   The correct order, deduced by Dolor from what each archmage remembered: flour, egg, sugar, salt,
-        ash.
 *   **Landro (the colossus)** - A monstrous colossus located in the Mournland, half-buried in the slope of
     Mount Ironrot.
     [[ch. 77](/dnd/campaign/chapter-77/), [ch. 78](/dnd/campaign/chapter-78/), [ch. 79](/dnd/campaign/chapter-79/),

--- a/_posts/2023-01-23-appendix.md
+++ b/_posts/2023-01-23-appendix.md
@@ -55,9 +55,11 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     [Mournland](https://eberron.fandom.com/wiki/Mournland); with Mercy, Justice, Pious, and Charity.
     [[ch. 76](/dnd/campaign/chapter-76/)]
 *   **Alustriel Silverhand** - [Female human wizard](https://forgottenrealms.fandom.com/wiki/Alustriel_Silverhand)
-    known for being intelligent, wise, charismatic, and very beautiful.
+    and high mage of Silverymoon, married to Malaina van Talstiv. The Sanctum is her home and she is
+    the one who opens and closes every portal for the adventurers. Unfailingly composed.
     [[ch. 55](/dnd/campaign/chapter-55/), [ch. 63](/dnd/campaign/chapter-63/), [ch. 64](/dnd/campaign/chapter-64/),
-    [ch. 67](/dnd/campaign/chapter-67/), [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/)]
+    [ch. 66](/dnd/campaign/chapter-66/), [ch. 67](/dnd/campaign/chapter-67/), [ch. 68](/dnd/campaign/chapter-68/),
+    [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/), [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Asura** - Female [aarakocra](https://www.dndbeyond.com/species/4-aarakocra) and member of
     the Ember Wing Wardens, entrusted with guarding the temple of Aish on Amonah. [[ch. 44](/dnd/campaign/chapter-44/)]
 *   **Ben Dabbler** - Male halfling who owns The Bargain Ben, a shop located in Wayside.
@@ -137,7 +139,8 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **Landro** - The intelligence built to pilot the colossus of the same name, and the only thing aboard
     it to survive whatever went wrong. Alone in [Mournland](https://eberron.fandom.com/wiki/Mournland) since
     the war, it joins the adventurers by transferring to a crystal that is affixed to Mond's staff.
-    [[ch. 84](/dnd/campaign/chapter-84/)]
+    It speaks telepathically to the whole group and narrates whatever it has not seen before.
+    [[ch. 84](/dnd/campaign/chapter-84/), [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Lyra Swiftarrow** - Female half-elven ranger who lives in the forest east of Wayside.
 *   **Lysan** - Female [Githyanki](https://forgottenrealms.fandom.com/wiki/Githyanki) crew member on the
     Lambent Zenith and sister to Zastral. [[ch. 68](/dnd/campaign/chapter-68/), [ch. 69](/dnd/campaign/chapter-69/)]
@@ -146,7 +149,8 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **Magnus** - Male human nobleman member of the Low Elves in Wayside. [[ch. 2](/dnd/campaign/chapter-2/),
     [ch. 3](/dnd/campaign/chapter-3/)]
 *   **[Malaina van Talstiv](https://5e.tools/bestiary/malaina-van-talstiv-veor.html)** - Female human assassin
-    and wife of Alustriel Silverhand. [[ch. 67](/dnd/campaign/chapter-67/), [ch. 74](/dnd/campaign/chapter-74/)]
+    and wife of Alustriel Silverhand, who manages every non-magical aspect of the Sanctum.
+    [[ch. 67](/dnd/campaign/chapter-67/), [ch. 68](/dnd/campaign/chapter-68/), [ch. 74](/dnd/campaign/chapter-74/)]
 *   **Marigold** - Female half-elf hostess & server at Dolly's Donuts in Elsemar. [[ch. 18](/dnd/campaign/chapter-18/)]
 *   **Mercy** - A [warforged](https://dnd5e.wikidot.com/lineage:warforged) pilgrim in
     [Mournland](https://eberron.fandom.com/wiki/Mournland); leader of the pilgrims, including Justice, Pious, Charity, and 404.
@@ -155,7 +159,8 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **Mordenkainen** - [Male human archmage](https://forgottenrealms.fandom.com/wiki/Mordenkainen)
     from the world of [Oerth](https://forgottenrealms.fandom.com/wiki/Oerth).
     [[ch. 63](/dnd/campaign/chapter-63/), [ch. 64](/dnd/campaign/chapter-64/), [ch. 67](/dnd/campaign/chapter-67/),
-    [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/), [ch. 84](/dnd/campaign/chapter-84/)]
+    [ch. 68](/dnd/campaign/chapter-68/), [ch. 74](/dnd/campaign/chapter-74/), [ch. 84](/dnd/campaign/chapter-84/),
+    [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Nyx Whiskerfang** - Male [tabaxi](https://forgottenrealms.fandom.com/wiki/Tabaxi) with tabby markings who is a
     [blood hunter](https://www.dndbeyond.com/classes/357975-blood-hunter) and hunts the undead on
     Amonah. [[ch. 39](/dnd/campaign/chapter-39/) - played by Chris Sells, [ch. 42](/dnd/campaign/chapter-42/) -
@@ -179,8 +184,9 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     [ch. 6](/dnd/campaign/chapter-6/)]
 *   **Tasha** - [Female human archmage](https://forgottenrealms.fandom.com/wiki/Iggwilv) from the world
     of [Oerth](https://forgottenrealms.fandom.com/wiki/Oerth). Also known as Iggwilv, Natasha, or Zybilna.
-    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 67](/dnd/campaign/chapter-67/), [ch. 74](/dnd/campaign/chapter-74/),
-    [ch. 75](/dnd/campaign/chapter-75/)]
+    Once Vecna is banished with the Chime of Exile, she is the one who will keep watch over him.
+    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 67](/dnd/campaign/chapter-67/), [ch. 68](/dnd/campaign/chapter-68/),
+    [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/), [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Thistlewick Brandlestrum** - Male gnome owner of The Fizz Hutt, a kombucha shop in Elsemar.
     [[ch. 20](/dnd/campaign/chapter-20/)]
 *   **Tella** - Male human owner of the Broken Spy Glass, an inn and pub in Elsemar and member of the Heart of
@@ -234,6 +240,13 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 
 ## Foes, monsters, & creatures
 
+*   **Batter golem** - A humanoid creature of pale golden batter that rises out of the mixing cauldron
+    when the Grimoire of Gastronomy's legendary confection is prepared correctly. It stands as tall as
+    Gven and half again as broad, with a dent where a face would be, and it speaks thickly enough to be
+    understood. Blades stick in it and vines slide off it; fire works.
+    [[ch. 85](/dnd/campaign/chapter-85/)]
+    *   It sprays batter over a fifteen-foot radius, turning the ground into difficult terrain.
+    *   Killed by fire, it keeps swelling from the heat and fills whatever room it died in.
 *   **Chimera** - The adventurers first significant challenge, where they slayed a
     [chimera](https://forgottenrealms.fandom.com/wiki/Chimera) that was troubling one
     of Ben's many fields in the area. After this conquest, the group began calling
@@ -350,8 +363,11 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **The Four Corners** - A cartography shop in the Scrivener's Ward of Elsemar, owned by Whichway.
     [[ch. 23](/dnd/campaign/chapter-23/)]
 *   **The Sanctum** - One of [Alustriel Silverhand's homes](https://steampunkapotamus.wordpress.com/2024/06/29/sanctum/)
-    located in Sigil, it is where she and the other mages bring the adventurers.
-    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 74](/dnd/campaign/chapter-74/), [ch. 84](/dnd/campaign/chapter-84/)]
+    located in Sigil, it is where she and the other mages bring the adventurers. It has baths, guest
+    rooms, a library, a solarium, and a kitchen the companions never find until ch. 85.
+    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 66](/dnd/campaign/chapter-66/), [ch. 67](/dnd/campaign/chapter-67/),
+    [ch. 74](/dnd/campaign/chapter-74/), [ch. 75](/dnd/campaign/chapter-75/), [ch. 84](/dnd/campaign/chapter-84/),
+    [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Waffle Wizards** - A diner in Food Alley of Elsemar that specializes in waffles, managed by K'ren.
     [[ch. 20](/dnd/campaign/chapter-20/)]
 *   **Weigh Anchor** - A dive bar by the docks of Elsemar, close to Davanor's warehouse. Boog is the bartender.
@@ -411,7 +427,9 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **Everwinter** - The mirror city of Neverwinter in the Shadowfell plane. [[ch. 59](/dnd/campaign/chapter-59/), [ch. 60](/dnd/campaign/chapter-60/)]
 *   **Ialos** - Community of [warforged](https://dnd5e.wikidot.com/lineage:warforged) pilgrims in
     [Mournland](https://eberron.fandom.com/wiki/Mournland), a village abandoned after
-    the Day of Mourning. [[ch. 76](/dnd/campaign/chapter-76/), [ch. 77](/dnd/campaign/chapter-77/)]
+    the Day of Mourning. The pilot's helmet taken from Landro is left with them on the way out of
+    Mournland. [[ch. 76](/dnd/campaign/chapter-76/), [ch. 77](/dnd/campaign/chapter-77/),
+    [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Mirganor** - The primary city on the east coast of Eritz, accessible by The Ha-derech.
     Before **The Conflict**, Mirganor was the center of the arcane orders, where the leaders lived,
     held congress amongst each other, and taught their arcane-based magic.
@@ -433,7 +451,8 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 *   **[Sigil](https://forgottenrealms.fandom.com/wiki/Sigil)** - Alustriel Silverhand's private bastion,
     [the Sanctum](https://steampunkapotamus.wordpress.com/2024/06/29/sanctum/) is located in this floating city ruled by
     [The Lady of Pain](https://forgottenrealms.fandom.com/wiki/Lady_of_Pain).
-    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 74](/dnd/campaign/chapter-74/), [ch. 84](/dnd/campaign/chapter-84/)]
+    [[ch. 64](/dnd/campaign/chapter-64/), [ch. 74](/dnd/campaign/chapter-74/), [ch. 84](/dnd/campaign/chapter-84/),
+    [ch. 85](/dnd/campaign/chapter-85/)]
 *   **Temple of Aish** - A temple dedicated to Aish that's located inside a volcano on the island of Amonah
     ([TODO - UPDATE Gustaf's map of the temple](/dnd/assets/images/ch50-drawn-map-route-800px.jpeg)).
     [[ch. 45](/dnd/campaign/chapter-45/), [ch. 46](/dnd/campaign/chapter-46/), [ch. 47](/dnd/campaign/chapter-47/),
@@ -463,6 +482,16 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     *   On a [critical hit](https://www.dicedragons.co.uk/blogs/tabletop-tips/how-do-critical-hits-work-dnd-5e)
         (rolling a natural 20) it emits a radiant glow where the target must roll a constitution saving
         throw or become blinded until their next turn.
+*   **The Grimoire of Gastronomy** - An enormous sentient cookbook kept in the Sanctum's kitchen, bound
+    in leather gone dark at the corners with its title stamped in gold. It flies, opens itself to a
+    requested page, and complains without pause. Mordenkainen was attempting a legendary confection from
+    its two hundred and fortieth page when the recipe failed, taking the page with it.
+    [[ch. 85](/dnd/campaign/chapter-85/)]
+    *   The five ingredients of the confection are Starlight Flour, a Dragon's Egg (a common name for a
+        large egg, and not from a dragon), Wintersheen Sugar, Void Salt, and Phoenix Ash. Added in the
+        wrong order the flour detonates; added correctly the mixture rises into a batter golem.
+    *   The correct order, deduced by Dolor from what each archmage remembered: flour, egg, sugar, salt,
+        ash.
 *   **Landro (the colossus)** - A monstrous colossus located in the Mournland, half-buried in the slope of
     Mount Ironrot.
     [[ch. 77](/dnd/campaign/chapter-77/), [ch. 78](/dnd/campaign/chapter-78/), [ch. 79](/dnd/campaign/chapter-79/),
@@ -495,6 +524,13 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
         Bearer can cast [Reverse Gravity](https://dnd5e.wikidot.com/spell:reverse-gravity) once per day,
         DC 18—a 50-foot radius, 100-foot high cylinder in which everything unanchored falls upward.
         Recovered from the head of the colossus Landro. [[ch. 84](/dnd/campaign/chapter-84/)]
+*   **Sunburst Shield** - Bilwin's round metal shield, bought from an inebriated dwarf at a Bluelake
+    market stall in Neverwinter after [Hanseath](https://forgottenrealms.fandom.com/wiki/Hanseath)
+    revealed it to him. The seller's account: "The Bearded One drank a beer with it, sang a rousin'
+    tune, and then called it the Sunburst Shield."
+    [[ch. 63](/dnd/campaign/chapter-63/), [ch. 73](/dnd/campaign/chapter-73/),
+    [ch. 78](/dnd/campaign/chapter-78/), [ch. 85](/dnd/campaign/chapter-85/)]
+    *   Once a day it shines a light as bright as daylight for ten minutes, which the undead dislike.
 *   **Tempest Edge** - Gven's greatsword, gifted to her by the storm giant, Veylara. It was the giant's
     5-1/2 foot long dagger and sister to her blue-tinted greatsword that Gven will be called upon to
     return someday. [[ch. 32](/dnd/campaign/chapter-32/)]

--- a/_posts/2023-01-23-appendix.md
+++ b/_posts/2023-01-23-appendix.md
@@ -238,7 +238,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
 ## Foes, monsters, & creatures
 
 *   **Batter golem** - A humanoid creature of pale golden batter that rises out of the mixing cauldron
-    when a legendary confection is prepared incorrectly. [[ch. 85](/dnd/campaign/chapter-85/)]
+    when a legendary confection is prepared. [[ch. 85](/dnd/campaign/chapter-85/)]
 *   **Chimera** - The adventurers first significant challenge, where they slayed a
     [chimera](https://forgottenrealms.fandom.com/wiki/Chimera) that was troubling one
     of Ben's many fields in the area. After this conquest, the group began calling

--- a/_posts/2026-08-17-chapter-85.md
+++ b/_posts/2026-08-17-chapter-85.md
@@ -1,0 +1,414 @@
+---
+title: "Chapter 85"
+show_date: true
+date: 2026-08-17T17:00:00-00:00
+sessiondate: "August 17, 2026"
+modified: 2026-08-17
+categories:
+  - campaign
+tags:
+  - co-written-with-claude
+  - eve-of-ruin
+  - fight
+  - sanctum
+---
+
+Standing in Lady Alustriel's parlor with their packs still on their shoulders, the companions hear the crystal in the head of Mond's staff speak into all of their heads at once. "That is a chair. There are a great many chairs in this house, and I have counted eleven of them since we arrived, which seems excessive. In my house there was one. The pilot sat in it. I did not sit, as I had nothing to sit with."
+
+"You'll get used to it," Dolor tells him.
+
+The construct has been talking since they came through the obsidian portal and it hasn't repeated itself yet. In the Mournland it narrated trees and ground and the peculiar business of walking on either. Here in the Sanctum it has moved on to furniture, doorknobs, and the purpose of a rug. Somewhere along the corridor it works out how to aim, and the voice stops arriving in the head of every servant within forty feet and narrows to the five of them. Everybody agrees this is an improvement, the servants most of all.
+
+---
+
+There are baths in the Sanctum. Not a river, not a basin of meltwater, not a cantrip thrown over a body too tired to care about the difference, but actual baths, with taps, in rooms built for nothing else. There are beds with more than one blanket on them. There's a meal at a table, brought out in courses by hands nobody can see, with more of it for anyone who asks, and the half-orc asks four times.
+
+Nobody says out loud that the place has started to feel like coming home.
+
+Setting her pack down inside the door, Gven cleans Tempest Edge before she does anything else. Somewhere out past all of this, a storm giant is wearing her father's medallion in one ear and waiting on a promise. The half-orc has no idea how she would even begin walking toward that from here. She leans the greatsword against the wall where she can reach it in the dark and lies there with her eyes open, because Torp turns up whenever her hands have nothing to do. It's been that way since Elsemar, and it's worse here than anywhere, because there's nothing in this house to kill and nowhere to walk to.
+
+Setting his staff against the nightstand, Mond lies looking at it for a long while. In Eritz he wore a pin on his lapel that told everyone what he was, so that they could decide how to feel about it. Here he has a war machine's mind riding on the head of that staff in front of three archmages, and nobody has asked him to register anything at all. He has stopped pretending, even privately, that he wants to go home.
+
+Sitting on the end of a bed with his bowler hat in his lap and his bare feet a good way short of the floor, Grindlefoot works through what to be next. Not a frog, since a frog has been done. An otter has promise, and so does a goat, though he can't think what for. He starts feeling sleepy partway through the list, somewhere around badger, entirely content.
+
+The tiefling sits up longest of any of them. Dolor has the third piece of the rod on the table beside him and his parents' pendant closed in one hand. A helmet's faded workshop mark keeps arriving behind his eyes every time he shuts them, and he still hasn't told anybody. He turns the pocket watch over twice, listens to it stutter, and puts it away.
+
+The dwarf doesn't sleep at all. Three words out of a puddle in the head of a colossus, no explanation attached to any of them, and a wall in his own mind where the answer ought to be. Lying in the dark in a very comfortable bed in a house in Sigil, Bilwin goes back at it, and back at it, like a tongue at a missing tooth.
+
+"You are all awake," Landro observes, into five heads simultaneously. "Every one of you, at the same time, in separate rooms, having spent the entire day telling me how badly you required rest. I do not wish to draw a conclusion from insufficient data. I would point out, however, that this is the third hour."
+
+"Go to sleep, Landro."
+
+"I do not sleep."
+
+Mond answers from the next room, "Neither do we, apparently."
+
+---
+
+The next morning is quiet, and the quiet is its own novelty. There's breakfast, and an hour after breakfast Grindlefoot goes looking and finds that there's also second breakfast, which he takes as evidence that the Sanctum is a fundamentally decent establishment. Alustriel passes through once and asks after their wounds. Tasha doesn't appear at all. Mordenkainen appears briefly, asks Dolor two questions about the third piece without waiting for either answer, and leaves again.
+
+Over the eggs, Gven raises the helmet. The companions had carried the pilot's silver helm out of the Mournland alongside the third piece and left it at Ialos on their way to the portal, laid on a shelf in the storeroom between the tapestries and the cracked docents. A warforged named Charity had thanked them in a voice that gave nothing away. Watching Mercy turn the thing over and set it down carefully, Dolor had said not one word about the mark on it.
+
+"I knew the man who wore that," Landro says. "He was not good at his work. He was slow with the charge sequence and he argued with the engineers about matters he did not understand, and twice he fell asleep in the chair. He was, however, present, which the others were not. I have thought about that a great deal and I have not decided what it is worth."
+
+Three rooms away, the kitchen of the Sanctum chooses that moment not to make a sound, and nobody thinks anything of it.
+
+Nothing else happens for most of the morning. It's the first day in a long while with nothing in it, and none of them are especially good at those.
+
+---
+
+Early in the afternoon there's a clanking. It's distant and unremarkable at first, the ordinary sound of a household doing household things, and then it develops an argument in the middle of it. Three voices, raised, none of them close enough to make out. The companions look up from what they're doing.
+
+"That is not how you do it."
+
+"I am the one reading it."
+
+"Then you are reading it wrong—"
+
+A fourth thing arrives, sharper than the rest. "Don't touch that!"
+
+And then comes a sound with no edges on it at all, a deep soft whumph that they feel in the floor more than hear. It's followed by a small "Oh, shit," and then by a silence that goes on, and on, until it feels like an answer.
+
+Wrinkling his nose at something underneath the smell of the room, Grindlefoot speaks first. "Something might be burning."
+
+Already on his feet with his stein in one hand, Bilwin has the particular certainty of a dwarf whose entire religion runs on fermentation and fire. "Not might. Is. And it's the good kind of burning gone bad, which is the worst kind there is." He turns a slow half circle, points, and announces it to the room. "Kitchen. Whoever was hungry, I'm sorry to say it, but lunch is burning."
+
+Pushing her chair back and standing up to the full six foot eight of her, Gven settles the matter. "Time to rescue lunch."
+
+---
+
+The companions have wandered a great deal of the Sanctum by now, through parlors and libraries and solariums and water closets with fixtures that spout upward. Not one of the companions has ever been in the kitchen, because the food simply arrives, and nobody has ever had a reason to find out where from.
+
+It turns out to be the size of a kitchen in an old castle and, the Sanctum being the Sanctum, half again as long as it has any business being. Down one side there's an open fireplace with a great iron hood. Beside it stands an oven big enough to walk into, its door a slab of black metal with a rune cut deep into the center.
+
+The first thing the companions notice is the flour. It's on everything: the tables, the hanging pans, the ceiling, the floor in soft drifts deep enough to hold a bootprint. It hangs in the air in a fine haze that makes the light through the high windows go solid.
+
+The second thing they notice is the bubble. Twenty feet across and faintly iridescent, it takes up the far corner of the chamber, and standing inside it are [Alustriel Silverhand](https://forgottenrealms.fandom.com/wiki/Alustriel_Silverhand), [Tasha](https://forgottenrealms.fandom.com/wiki/Iggwilv), and [Mordenkainen](https://forgottenrealms.fandom.com/wiki/Mordenkainen). All three of them are spotless. Not a speck on any of them. In a room where every other surface has gone white, the three most powerful people the companions have ever met are immaculate, and shouting at one another, and none of it comes through.
+
+Taking this in, Bilwin offers his assessment. "I hate when beer does that."
+
+"That is a bubble," Landro says from the top of Mond's staff. "There are people inside it and they do not look as though they are enjoying themselves. I would like to know whether they were put in it or whether they climbed in, because the answer changes what sort of afternoon this is going to be."
+
+"That," says Mond, "is the question." Letting his sight go sideways into the thing, the sorcerer studies it for a moment before he explains it to the others. "It's a [globe of invulnerability](https://www.dndbeyond.com/spells/2619051-globe-of-invulnerability). You cast it on purpose, around yourself, to keep things out, and it's very good at that, which is the whole point of it. What I can't tell you is why it's doing this, or why three people who could each unmake this building are standing inside one looking annoyed."
+
+The voices reach them the way voices reach a person through a thick door underwater, warped and slow, until the surface of the globe settles and the words come through clearly enough to follow.
+
+Tasha gets there first. "He cast it on purpose. I want you to understand that before you feel sorry for anybody in here. The room was about to be full of flour, and he did not wish to be in the room while that happened, and so he solved the problem of the flour with a fourth-level abjuration. He is very proud of it. You can see how proud of it he is."
+
+"I did not wish to be in it," Mordenkainen agrees. "I am not in it."
+
+Alustriel doesn't turn her head. "You are not in anything. That is precisely the difficulty."
+
+"I did not deliberately cast it into the confection. I cast it around myself, which is the correct and stated use of the spell, and the confection came apart at the same moment and took an interest in what I was doing." He pauses, conceding a very small point. "These things happen when one is working."
+
+"I would rather be dusty," says Alustriel.
+
+Raising a hand, Mond throws [Dispel Magic](https://www.dndbeyond.com/spells/2618962-dispel-magic) at the globe, and it has roughly the effect of a pea thrown at a wall.
+
+Having watched all of this with her arms folded, Gven draws Tempest Edge from her hip in one long motion. She ambles across the kitchen, plants her feet, and swings the storm giant's blade into the bubble as hard as she can. The greatsword bounces, and it bounces with real enthusiasm, sending the half-orc back a step with her arms up and her braid swinging, more startled than hurt. She looks at the blade, and then at the bubble, and shrugs.
+
+Turning to face her fully, Mordenkainen speaks, and whatever is wrong with the sound, his voice arrives with perfect clarity. "It is called a globe of invulnerability. I would like you to consider the second half of that name at your leisure, and then to consider what it might have been chosen to convey. Do you understand what the word invulnerability means?"
+
+Gven's tusks show. "Do you understand who I am?"
+
+A pause follows. "That is a fair point." The archmage considers her a moment longer, then holds up both clean hands and speaks with great care, one word at a time. "Big sword. No hurt bubble. No hurt."
+
+From behind him, Tasha adds, "Marvelous. Now they will work very hard to let us out, and quickly too, and with such fondness in their hearts."
+
+Giving him a look that would flatten a lesser wizard, Gven crosses to a chair in the corner with a cask beside it. She fills a mug to the brim, sits down, kicks her boots out in front of her, and settles in to watch other people solve a problem for once.
+
+Alustriel watches her do it. "That is cooking wine."
+
+"Mm."
+
+"One does not drink cooking wine."
+
+"This one does."
+
+---
+
+A book comes down out of the rafters on wings of beating paper and settles in the air in front of the companions at about eye height. It's enormous, its cover worked leather gone dark at the corners, and stamped across it in gold are the words *The Grimoire of Gastronomy*.
+
+"Oh, thank the gods," it says. "People. Functional people, with hands, who did not spend the morning explaining to me that they had read me already."
+
+From inside the globe, Mordenkainen remarks, "That's where that got to."
+
+Ignoring him entirely, the book carries on. "He was reading me. He was attempting a legendary confection out of my two hundred and fortieth page, which is not a page one attempts on a whim before luncheon, and he failed utterly. He then took steps to protect his robes. I would like everyone present to note which of us in this room he thought to put inside the bubble, and which of us he left on the table next to an open flame."
+
+"I did not fail utterly," says Mordenkainen, mildly, his voice drifting through the globe. "I merely attempted a method that did not work. And put flour over everything. And cracked the oven's heat rune."
+
+The Grimoire's pages riffle in what is unmistakably a flinch. Over by the oven, the rune cut into the black door has a hairline running through it, and the hairline is glowing.
+
+"How long?" Dolor asks.
+
+Tasha's voice comes through sweet as anything. "Until it melts this side of the building? Nobody knows. Nobody has ever cracked one and then stood about asking questions, because the people who crack them are usually somewhere else by now. Isn't that exciting."
+
+"Can it be turned off?"
+
+"It cannot be turned off," the book says. "It can only be finished. Cooking is not a thing one abandons partway, and neither, I might add, is reading, and if either had been done properly this morning we would all be eating by now."
+
+Stepping closer to the hovering tome, the tiefling tries a different question. "Show us the page he was working from."
+
+"Certainly. I would be delighted to show you the page. I have been waiting all afternoon for somebody to ask me to show them the page." It opens itself, hard, and slaps flat in the air. Where the recipe should be there's a brown-black crater with a fringe of ash around it, the paper curled back on itself, three or four legible words scattered around the rim like survivors. "Would you like one of your arms burnt off? No? Then perhaps some sympathy, and then perhaps somebody with hands can put the ingredients in the pot."
+
+---
+
+Five ingredients sit out on the long table, and the drifts of flour part around them. There's a sack labeled **Starlight Flour**, which is what covers the room, and a single egg the size of a melon with veins of dull gold shot through the shell, marked **Dragon's Egg**. Beside them stand a jar of **Wintersheen Sugar**, a stoppered crock of **Void Salt** that Dolor decides not to open, and a small iron canister of **Phoenix Ash** that's warm through the metal.
+
+"That is not," the Grimoire notes, "an actual dragon's egg. It is a common name for a large egg. This is exactly the sort of thing people never read carefully, and then they are disappointed, and then it is somehow my doing."
+
+"What happens if the order's wrong?" Grindlefoot asks, and every head in the kitchen turns toward the globe of invulnerability with three archmages standing inside it.
+
+Pulling a stool over and sitting down in front of the ingredients with his tail curled around one leg of it, Dolor finds a wooden mixing spoon on the table, longer than his forearm and worn pale at the handle. He picks it up. "Then somebody tell me the order."
+
+What follows takes rather longer than the oven's broken rune probably has.
+
+Tasha gets in first, in the tone of a woman who has not once been wrong within living memory. "Flour first. One always starts with the flour. I am not guessing and I am not remembering something my mother told me. I read it this morning, off that page, while it still had words on it."
+
+From her chair, Gven calls out, "Did you read that, or is that just what you reckon?"
+
+"I read it." A pause. "Also, I know how to bake. I have a long memory, half-orc, and I keep everything in it that has ever been said to me. I am not the one in this room with the memory of a goldfish."
+
+Gven's mug stops halfway to her mouth. She looks at the archmage for a long moment through the shimmer of the globe, then drinks and says nothing at all, which is, in its own way, the lesson landing.
+
+Alustriel offers the second piece of it. "The sugar goes in before the salt."
+
+Mordenkainen supplies the rest. "The egg goes before the sugar, and the ash is last. Of that much I am entirely certain, and I would stake a good deal on it, which under the circumstances I appear to have already done."
+
+"You're certain," Dolor says. "You're certain, and you're the one who did it wrong."
+
+"I looked across many methods at once. I think of many things simultaneously, which is a considerable advantage in most work and, I concede, an inconvenience in baking."
+
+"You weren't paying attention."
+
+"I cast [Mage Hand](https://www.dndbeyond.com/spells/2619008-mage-hand) and had it throw everything in," the archmage admits, without a flicker. "I do not remember the order."
+
+Having spent the entire conversation quietly measuring the distance from the cauldron to the doorway, Mond speaks up. "Nobody has answered the halfling. If he gets it wrong, does it go poof, or does it go boom? Because those are two quite different afternoons and I'd like to know which one I'm standing in."
+
+"Poof," says the Grimoire. "The flour goes up, all at once, and everything within twenty feet wears it for a week. That is what happened the first time, and you can see for yourselves where it got everyone."
+
+"Poof I can work with."
+
+"You'd think," Bilwin says, "that a recipe would put the warnings at the front."
+
+"The warnings," says the Grimoire, with enormous dignity, "come at the end."
+
+Holding up a hand until the kitchen goes quiet, Dolor turns the silver signet ring on his finger once with his thumb, the habit that steadies him, and works it through aloud. "Three of you disagree about almost everything, but not about the same things. Tasha puts the flour first and nobody has argued with her. Mordenkainen wants the egg before the sugar and the ash last. Alustriel wants the sugar before the salt. Line those up and there's only one order left that doesn't break somebody's rule." He looks at the table and the four gaps arrange themselves. "Flour. Egg. Sugar. Salt. Ash."
+
+The kitchen thinks about it.
+
+Alustriel nods once. "That is correct."
+
+Mordenkainen inclines his head. "That is what I said."
+
+Tasha does not let it stand. "It is emphatically not what you said."
+
+From her chair, and without getting out of it, Gven offers her contribution. "Are we doing this, or are we discussing it until the building melts?"
+
+Walking over and putting a hand flat between the seated tiefling's shoulder blades, the dwarf casts [Death Ward](https://www.dndbeyond.com/spells/2618989-death-ward) into him without being asked. "Now, I can't make it not hurt, and I want to be honest with you about that, because if it goes wrong it's going to hurt a great deal. But you'll live through it. Probably. Mostly. I'm going to go and stand behind you now."
+
+"Naturally."
+
+"Well behind you."
+
+"Yes."
+
+The sorcerer retreats to the doorway and stands in it with one foot out in the hall, calculating. The halfling puts his bowler hat back on and holds it there with both hands. Gven doesn't get up.
+
+The flour goes in first, in a soft avalanche. Then the egg, cracked two-handed on the cauldron's iron lip, and then the sugar, which frosts the rim white, and then the salt, which makes a sound going in that salt has no business making. Between each one the tiefling works the spoon through the mixture the way he would work a mainspring back into a watch, unhurried, all the way to the bottom. He hesitates over the ash. Then he tips the canister, and the black dust goes down into the cauldron.
+
+---
+
+The cauldron shakes, and then it shudders, and then it shimmies, and then it stops. For three full seconds the kitchen is perfectly silent.
+
+A low murmur starts down in the iron and gets louder. The surface of the mixture lifts and bubbles and climbs the sides, and the Grimoire of Gastronomy flings itself up into the corner of the ceiling and shrieks with pure professional joy. "It's rising! You did it! It's rising!"
+
+Something else happens on the other side of the room at the same moment, and it takes the companions a second to understand what any of them is looking at. The kitchen splits, not the floor and not the walls but the room itself. A seam opens down the length of it with both halves staying exactly where they are, offset by a hand's breadth and by something considerably worse than distance. The fireplace has two hearths that are the same hearth. Looking at the long table makes the backs of everyone's eyes ache. Down inside the seam, cut into the substance of the place itself, is a rune the size of a cartwheel with a piece missing from its edge.
+
+Turning to Mordenkainen, Alustriel Silverhand, who has been unfailingly composed in the presence of these companions since the day they fell into her parlor, says, "You cracked the rune, you motherfucker."
+
+Talking over the top of her, Tasha gets to the practical part. "That needs mending, or it melts the whole side of the building, and I do mean the side and not the kitchen. Now. Not soon."
+
+Already moving toward the seam, Dolor calls back over his shoulder. "How? Tell me how."
+
+"Recarve it," Mordenkainen says. "Redraw the room. It is a rune like any other rune, only larger and holding rather more, and it will take the correction from anyone who can read the part that survived. You have tools, I imagine. Thieves' tools, tinkering tools, whatever it is you keep in that jacket."
+
+"How long do I have?"
+
+"Now," says the archmage, and settles into it with evident pleasure. "An interesting word, now. It is not a duration. It is the edge between what has occurred and what has not, and it has no width whatsoever, which means that strictly speaking one cannot act during it at all. One can only act very near it. I have written on this."
+
+"How long."
+
+"Thirty seconds. Approximately."
+
+Behind him, the cauldron heaves, and something climbs out of it. It comes over the iron lip in a single slow fold, like batter over the edge of a bowl, then gathers itself upright on the flagstones with a wet sucking noise and keeps going up. Arms. Legs. A head with no face on it, only a dent where a face would go. It stands as tall as Gven and half again as broad, made entirely of pale golden batter, and it roars.
+
+From up in the ceiling, the Grimoire supplies the word with relish. "That is a batter golem. I have three pages on them and nobody has ever once read past the first."
+
+"That is food," Landro says. "Why is the food standing up?"
+
+Gven sets down her mug.
+
+---
+
+<!-- Fight choreography: The batter golem -->
+
+<!-- Initiative rolls:
+Mond - 20
+Gven - 18
+Grindlefoot - 8
+Bilwin - 8
+Dolor - 6
+-->
+
+<!-- Round 1 -->
+
+Not waiting to be told, the sorcerer throws a [Fire Bolt](https://www.dndbeyond.com/spells/2618890-fire-bolt) that buries itself in the golem's chest with a hiss. A smell goes up that stops being alarming and starts being appetizing about halfway across the room.
+
+Rising out of the chair without hurrying, the half-orc draws Tempest Edge and then stops, because she is looking at what she is about to put five and a half feet of storm giant steel into. She tries it anyway. The blade goes in to the depth of a hand's width, which is when the batter closes around it, and the half-orc has to plant a boot on the thing's hip and haul with her shoulders to get her sword back. It comes free trailing long golden ropes. She looks at the blade, and at the mess of it, and at the creature. Pulling one of her hand axes from her belt with her free hand, she buries it in the golem's flank instead, which works considerably better. Three long steps sideways put her between the creature and the seam in the room, where the tiefling is going to be kneeling in a moment, and she plants her feet there.
+
+Meaning well, the druid raises both hands and sends [Entangle](https://www.dndbeyond.com/spells/2618963-entangle) at the golem. Vines erupt out of the kitchen flagstones in a twenty-foot square that includes, in order, the golem, Gven, and Dolor. The vines attempt to grip the golem's gloppy body and appendages, but slide off to land on the floor. The half-orc tears loose with a snarl and a certain amount of ripping. Dolor, who has spent his whole adult life losing arguments with rope, is instantly and comprehensively caught. The halfling's hands come down. "Uh, oops."
+
+Turning on Gven, the golem roars into her face from a distance of about eight inches, then leans back, opens the dent where a mouth ought to be, and sprays her at close range. It's like being hit with a wet mattress. The half-orc takes it across the chest and shoulders and stays upright, but the batter goes everywhere, fifteen feet in every direction and ankle-deep. It's thick and warm and clinging, so that every boot in the area is now part of the floor and nobody in the group is going anywhere at better than a crawl.
+
+Surveying the situation and wiping batter off his beard with two fingers, the dwarf looks up at the creature and delivers his opinion of it. "You look like you could bake a little longer." He raises the Sunburst Shield and a column of fire and radiance comes down out of the kitchen ceiling. The [Flame Strike](https://www.dndbeyond.com/spells/2618937-flame-strike) punches a hole clean through the middle of the golem and leaves the edges of it browned and crisping, and the smell that fills the chamber is, unmistakably, fresh bread. The dwarf breathes it in. "Ah. The smell of victory."
+
+From a rack in the far corner, two whisks lift off their hooks and come across the room end over end. The first goes past Dolor's ear. The second catches Gven across the side of the head with a tang that everybody hears.
+
+Unable to move his legs and not bothering to try, the tiefling lies face down in the seam of the room with his tools out. He works the rune's broken edge, reading the shape of the thing off the three-quarters of it that survive and cutting the rest by feel. It's the same work as a watch escapement, except that the watch is a room. He gets most of the way. Not all of it.
+
+<!-- Round 1 damage dealt:
+Mond (Fire Bolt) - 15
+Gven (Tempest Edge) - 13; (hand axe) - 9
+Bilwin (Flame Strike) - 21 fire + 10 radiant
+Party damage taken:
+Gven - 11 bludgeoning (batter spray) + 12 (whisk)
+Dolor - 0 (whisk missed); restrained by Grindlefoot's Entangle, failed to break free
+Note: Entangle's area caught the golem, Gven and Dolor. The vines could not hold the golem's
+batter and slid off it. Gven broke free; Dolor did not. Batter difficult terrain, 15 ft radius,
+movement quartered. Dolor's first Arcana check on the rune: partial success.
+-->
+
+<!-- Round 2 -->
+
+Throwing a grasping spectral hand across the room, Mond closes it on the golem's shoulder, and the [chill](https://www.dndbeyond.com/spells/2618924-chill-touch) blackens the batter where it grips. Whatever the creature has been doing to knit itself back together stops doing it.
+
+Swinging at the golem and missing, which is the batter's fault and not hers, the half-orc takes a whisk out of the air on the backswing instead, and it goes into the wall and stays there, quivering. The golem answers by hitting her twice with its whole body, chest first, both times. The first drives the breath out of her. The second puts her down on one knee in the batter, and when she gets up there's blood in it. Gven isn't doing well and everybody in the room can see it.
+
+Looking at that, and then at the fifteen feet of glue between himself and everybody else, the druid jumps into the middle of it. He goes in up to his knees, planted like a fencepost, and casts [Freedom of Movement](https://www.dndbeyond.com/spells/2619031-freedom-of-movement) on Gven, Dolor, and Mond, and all three of them come unstuck at once. The halfling doesn't include himself, and so Grindlefoot stays exactly where he is, up to the shins in batter, in a bowler hat, moving at a quarter of his usual speed.
+
+Bringing the fire down a second time, the dwarf finds that the golem has learned something in the last few seconds and manages to be mostly elsewhere, so the [column](https://www.dndbeyond.com/spells/2618937-flame-strike) only takes a piece off its shoulder. The piece is nicely done. Meanwhile the remaining whisk comes at Dolor, misses, wheels around, and hits Gven again in the same spot.
+
+Down in the seam, the tiefling finishes the rune. There's a white flare, hard and silent, that leaves everyone in the kitchen blinking, and the two halves of the room come back together. It's one kitchen again, with one fireplace, and one long table, and one perfectly ordinary aching in the back of nobody's eyes. Getting up out of the batter, Dolor announces the result. "Done."
+
+<!-- Round 2 damage dealt:
+Mond (Chill Touch) - 13
+Gven - missed golem; hit whisk for 8 (destroyed)
+Bilwin (Flame Strike) - 10 fire + 11 radiant (golem saved for half)
+Party damage taken:
+Gven - 17 + 15 (golem slams) + 11 (whisk)
+Party support:
+Grindlefoot - Freedom of Movement on Gven, Dolor, Mond. Grindlefoot himself now in
+difficult terrain at quarter speed.
+Dolor - second Arcana check on the rune: success. Room sealed.
+-->
+
+<!-- Round 3 -->
+
+Mond's next [Fire Bolt](https://www.dndbeyond.com/spells/2618890-fire-bolt) goes in deeper than either of the last two and comes out the other side.
+
+Freed of the vines and the batter both, the half-orc takes a hand axe to the golem twice and misses with both swings, batter flying off the blade in ribbons. "You're the best smelling opponent I've ever fought," she tells it.
+
+The golem answers her. It comes out thick and gluey and from somewhere well back of where a mouth should be, and every single person in the kitchen understands it. "Wisshh ah could shay the shame abou' you." Then it comes at her with both fists, and the first one lands, and Gven takes it the way she has taken everything since Wayside, which is standing up.
+
+Having seen enough, and still stuck at the shins, and still three feet of halfling, the druid pushes his hands out and pours [Heal](https://www.dndbeyond.com/spells/2619159-heal) across the kitchen into the half-orc, and the worst of it closes over.
+
+Which leaves Bilwin, who has been waiting for his moment and is fairly sure this is it. "I want bread with dinner tonight," the dwarf announces, and calls down a [Guiding Bolt](https://www.dndbeyond.com/spells/2618923-guiding-bolt). The light goes through the batter golem, and the batter golem comes apart.
+
+<!-- Round 3 damage dealt:
+Mond (Fire Bolt) - 23
+Gven (hand axe) - miss, miss
+Bilwin (Guiding Bolt) - 30 (kill)
+Party damage taken:
+Gven - 16 (golem fist; second missed)
+Party healing:
+Gven - 20 (Grindlefoot, Heal)
+-->
+
+---
+
+The globe of invulnerability goes out like a soap bubble, and three archmages step down onto the flagstones of their own kitchen without a mark on any of them, into a room that's entirely flour and batter and the smell of baking. Looking down at himself, and then around at everything else, Mordenkainen wears the expression of a man whose plan has worked in every particular.
+
+Alustriel recovers first. "Well. Thank you."
+
+That's as far as she gets. The batter golem died on fire, and heat is heat, and the thing on the flagstones has stopped being a creature and gone back to being dough. It swells, and it swells fast, out from the middle in a slow golden wave. It takes the long table and the fireplace and the oven, comes up the walls, and reaches the doorway well before anybody in that kitchen does. It fills the room, and then it fills the room around all nine of them, warm and close and smelling like the best thing anybody has ever smelled.
+
+Somewhere inside it, muffled and entirely dry, Mordenkainen has the last word. "I suppose we won't be putting candles on Dolor's birthday cake now." A pause. "Everyone may begin eating."
+
+<!-- NOTES -->
+
+<!-- Downtime chapter at the Sanctum, between the Mournland and whatever comes next. No piece of the
+Rod recovered and no level gained; the party still holds three of seven, kept separate rather than
+clicked together: commune, arcane gate, and reverse gravity.
+-->
+
+<!-- Ialos: the pilot's helmet was left with the warforged pilgrims on the way out of the Mournland,
+which closes the debt from ch. 82. It is inert now that the pilot's chamber is destroyed. The control
+crystal promised alongside it stays with the party as Landro's vessel.
+-->
+
+<!-- Open threads touched this chapter:
+  - Bilwin still has no memory behind Landro's "You came back" (ch. 84) and spends the night on it.
+  - Dolor still hasn't told anyone his parents helped build Landro. Landro mentions knowing the dead
+    pilot, and Dolor says nothing.
+  - Gven's debt to Veylara — the blade goes back one day, and the storm giant wears her father's
+    medallion until it does.
+  - Mond has stopped pretending he wants to return to Eritz.
+  - Tasha's goldfish lesson from ch. 74 is now something she can refer to out loud.
+-->
+
+<!-- The Grimoire of Gastronomy is the campaign's fourth talking magic item, after Whelm, Wave and
+Blackrazor. Voice rule: every line refers back to its own injury or its own dignity.
+-->
+
+<!-- em dash: — | Mac kebyoard shortcut = Option + Shift + Dash (-) -->
+<!-- https://oatcookies.neocities.org/dndmoney to convert copper, silver, gold, and more into CP -->
+<!-- Frequently used links:
+  [Barbarian rage](https://www.thegamer.com/dungeons-dragons-dnd-barbarian-rage-explained-guide/)
+  [Bardic inspiration](https://www.dndbeyond.com/classes/1-bard#BardicInspiration-75)
+  [Chaos Bolt](https://www.dndbeyond.com/spells/14761-chaos-bolt)
+  [eagle eyesight](https://dnd5e.wikidot.com/barbarian:totem-warrior#toc2)
+  [Eldrich Blast](https://www.dndbeyond.com/spells/2619161-eldritch-blast)
+  [Green-Flame Blade](https://dnd5e.wikidot.com/spell:green-flame-blade)
+  [Guiding Bolt](https://www.dndbeyond.com/spells/2619136-guiding-bolt)
+  [Hanseath](https://forgottenrealms.fandom.com/wiki/Hanseath)
+  [Hellish Rebuke](https://www.dndbeyond.com/spells/hellish-rebuke)
+  [hurdy-gurdy](https://en.wikipedia.org/wiki/Hurdy-gurdy)
+  [Mind Spike](http://dnd5e.wikidot.com/spell:mind-spike)
+  [Shillelagh](https://www.dndbeyond.com/spells/2249-shillelagh)
+  [Spiritual Weapon](https://www.dndbeyond.com/spells/2263-spiritual-weapon)
+  [Tasha's Mind Whip](https://dnd5e.wikidot.com/spell:tashas-mind-whip)
+  [Uncanny Dodge](https://roll20.net/compendium/dnd5e/Rogue#toc_10)
+  [Wild Shape](https://www.dndbeyond.com/posts/635-druid-101-wild-shape-guide)
+    - [Giant Wolf Spider](https://www.dndbeyond.com/monsters/16900-giant-wolf-spider)
+-->
+<!--
+  Lists of spells for the classes:
+    - Bard spells (Bilwin): https://www.dndbeyond.com/spells/class/1-bard
+    - Cleric spells (Bilwin): https://www.dndbeyond.com/spells/class/cleric 
+    - Druid spells (Grindlefoot): https://www.dndbeyond.com/spells/class/druid
+    - Sorcerer spells (Mond): https://www.dndbeyond.com/spells/class/sorcerer
+    - Warlock spells (Dolor): https://www.dndbeyond.com/spells/class/warlock
+  Monsters: https://www.dndbeyond.com/monsters
+  Damage types: https://www.wargamer.com/dnd/damage-types
+  Luck (Bilwin): http://dnd5e.wikidot.com/feat:lucky
+-->
+<!-- Directions on a boat:
+  Port = left side
+  Starboard = right side
+  Bow = front
+  Aft = back (inside the ship, on board)
+  Stern = back (outside, offboard)
+-->
+
+<!-- Guest player:  -->


### PR DESCRIPTION
Chapter 85, the Sanctum kitchen. Prose is Tod's final edit from the session doc.

## The chapter

`_posts/2026-08-17-chapter-85.md` — 5,584 words of prose.

**Note on the filename.** The request said `2026-07-17`; I used **`2026-08-17`**, the session date, which the front matter also carries. A July date would sort chapter 85 before chapter 83 (2026-07-20). Easy to rename if that was intentional.

**Restoring the export.** The Docs export flattens paragraph breaks to single newlines, so every paragraph was rebuilt and the curly apostrophe normalised. Multi-line HTML comment blocks were kept intact rather than split. Verified: 19 comment open/close pairs balanced, 9 scene breaks, no curly quotes.

**Carried forward from chapter 84**, as asked. The reusable reference blocks are verbatim — em dash shortcut, coin converter, frequently-used links, class spell lists, boat directions, guest-player line.

The three *chapter-status* blocks I rewrote for 85 rather than copying, because ch. 84's versions state things that are no longer true here — most visibly **"Owed to Ialos: the pilot's helmet still goes to the warforged pilgrims"**, which this chapter resolves. Say the word if you'd rather they were verbatim.

**One correction to a choreography note.** Your edit changed the Entangle from missing the golem to catching it and sliding off its batter. The round-1 comment still said "Entangle missed the golem," so it now reads:

> Entangle's area caught the golem, Gven and Dolor. The vines could not hold the golem's batter and slid off it. Gven broke free; Dolor did not.

## Appendix pass

**New entries** — the Grimoire of Gastronomy (Objects, with the five ingredients and the solved order as sub-bullets), the batter golem (Foes), and the **Sunburst Shield**, which had no entry despite being named in four chapters.

**Cited ch. 85** on Alustriel, Tasha, Mordenkainen, Landro, the Sanctum, Sigil and Ialos.

**Tracked backfills done in the same pass** (item 3 on the to-do list):

| Entry | Added | Removed |
|---|---|---|
| Alustriel Silverhand | 66, 68, 85 | — |
| Tasha | 68, 85 | — |
| Mordenkainen | 68, 85 | **75** — he isn't in that chapter |
| Malaina van Talstiv | 68 | — |
| The Sanctum | 66, 67, 75, 85 | — |

Also filled out the thin descriptions. Alustriel's read "known for being intelligent, wise, charismatic, and very beautiful," which is a stat block rather than a person; Tasha's didn't mention that she's the one who'll keep Vecna after the Chime.

Both checks from `appendix-guide.md` pass: no chapter link is missing its trailing slash, and every section I touched is alphabetical. (The Grimoire initially landed under T — moved to G, matching the Four Corners / Sanctum precedent of sorting past a leading "The". The two pre-existing disorders in Shops and the known Thistlewick/Tella one are untouched.)

## Reference docs

- **`story-so-far.md`** — coverage now 1–85, arc VI extended with the chapter, and the **Ialos helmet debt struck through and marked closed**.
- **`npc-characters.md`** — gains the Grimoire of Gastronomy, the campaign's fourth talking magic item after Whelm, Wave and Blackrazor and the first that isn't a weapon. Voice rule: *every line comes back to its own injury or its own dignity.*
- **`to-do-list.md`** — seven items checked off. 51 remain.

## Not included

No `levelup` tag and no rod piece — this is a downtime chapter. The `landro` tag stays dropped per your note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)