### PR TITLE
Update reference docs for chapter 53

### DIFF
--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -17,8 +17,12 @@ class, height or age, so it sits outside the table with its own section.
 
 > **Gear** is recorded in two places: each character's own entry for what they carry day to day, and
 > **Gear bought off-page — chapter 55** at the bottom, which is the full list from the Neverwinter
-> shopping trip that was never written. Items acquired on-page (Whelm, Gleaming Blade, the Sunburst
-> Shield, Dolor's pocket watch) are described in `story-so-far.md` and the appendix.
+> shopping trip that was never written. Items acquired on-page (Gleaming Blade, the Sunburst Shield,
+> Dolor's pocket watch) are described in `story-so-far.md` and the appendix.
+>
+> **The three White Plume weapons are gone.** Whelm, Wave, and Blackrazor were carried for two
+> chapters and lost in ch. 53 — see "Whelm, and losing it" under Bilwin. Do not arm anyone with them
+> after ch. 52.
 
 ---
 
@@ -58,6 +62,18 @@ not the dwarven norm and is a deliberate character choice. He lets it grow over 
 the Rod of Seven Parts era (ch. 64 on) it's full and reaches past his neck to nearly his chest —
 still not down to the belt like a proper dwarf's. Ch. 67 confirms it: in the bath, his belly-length
 beard floats just under the water. **Check where you are in the timeline before describing it.**
+
+**Whelm, and losing it.** For two chapters Bilwin carries **Whelm**, the telepathic dwarven
+warhammer pulled from under a vampire's sarcophagus in ch. 50. It talks to him and only him — *"Aye,
+lad, let's pound this damnable beast!"* (ch. 52) — and it is the closest he has come to a real
+weapon, the hurdy-gurdy notwithstanding. Ch. 53 opens with him "standing tall after the battle,
+Whelm clutched tightly in his hand and his head tipped a little to the side, as though he's listening
+to something," which is the last good moment either of them gets. Minutes later the hammer vibrates
+itself out of his grip — the prose makes a point of dwarven hand strength failing — and hits the
+floor alongside Wave and Blackrazor. **Neither Bilwin nor anyone else has mentioned it since** — no
+chapter from 56 on refers to the hammer at all, and nothing in the prose marks the loss. (Dolor
+held **Wave** for a matter of minutes in the same scene, long enough for it to frost over and
+cold-burn his hand open; Tham then threw it into the rift.)
 
 ## Dolor Vagarpie
 

--- a/.claude/npc-characters.md
+++ b/.claude/npc-characters.md
@@ -29,10 +29,11 @@ built out.
 
 | | Species / role | Home | First seen | Chapters |
 |---|---|---|---|---|
-| **Alustriel Silverhand** | Human wizard, high mage of Silverymoon | The Sanctum, in Sigil | ch. 55 (unwritten) | 63, 64, 66, 67, 68, 74, 75, 85 |
+| **Alustriel Silverhand** | Human wizard, high mage of Silverymoon | The Sanctum, in Sigil | **ch. 53** | 53, 63, 64, 66, 67, 68, 74, 75, 85 |
 | **Tasha** | Human archmage, of Oerth | — | ch. 64 | 64, 67, 68, 74, 75, 85 |
 | **Mordenkainen** | Human archmage, of Oerth | Oerth | ch. 63 | 63, 64, 67, 68, 74, 84, 85 |
 | **Malaina van Talstiv** | Human assassin; Alustriel's wife | The Sanctum | ch. 67 | 67, 68, 74 |
+| **Dagult Neverember** | Human; Lord of Neverwinter | Neverwinter | ch. 53 | 53, 62, 63; referenced 56, 57 |
 
 The three archmages cast *Wish* together to negate Vecna's power and got five adventurers instead
 (ch. 64). That accident is the reason for every scene any of them are in. **Alustriel is the host
@@ -47,8 +48,8 @@ undercuts Mordenkainen**, constantly and with enjoyment. **Mordenkainen does not
 
 - **Hair** long silver. **Eyes** sparkling blue. Tall, slender, statuesque; sits and moves
   gracefully.
-- **Clothing** light blue robes in ch. 63; by ch. 74, "a stunning gown that seems to flow
-  majestically even when she's sitting still."
+- **Clothing** a cloak that "shimmers like a starlit sky" in ch. 53; light blue robes in ch. 63; by
+  ch. 74, "a stunning gown that seems to flow majestically even when she's sitting still."
 - **Carries** a thin, dark wooden staff topped with a
   [unicorn's head](https://forgottenrealms.fandom.com/wiki/Staff_of_Silverymoon) — the Staff of
   Silverymoon (ch. 63).
@@ -80,6 +81,32 @@ The imperative register, in full:
 
 **She addresses people by role, warmly**: "my dear dwarf," "master dwarf," "young sorcerer," "sir
 dwarf." Her farewell is a formula: *"Farewell and may courage be your constant companion."*
+
+**Her first appearance is ch. 53, and it is the only time the party sees her act.** The temple
+cavern is flooding with boiling water and all five of them are drowning in it when she stops time —
+the surge freezes mid-crash, drops hang in the air "like crystal teardrops," the heat vanishes — and
+walks through it untouched. Her whole scene is five short lines, and the register is the imperative
+one at its most extreme:
+
+> "Enough."
+
+> "You have played into his hand."
+
+> "But there are still more cards to be dealt."
+
+> "We shall soon see what you're made of."
+
+The narration is explicit about the manner: *"She speaks without urgency, only truth."* She does not
+introduce herself, explain, or wait — she is never named in the chapter at all, only "The Lady," and
+the party wakes up in Neverwinter without having been told anything. **This is the baseline her
+later warmth is measured against**, and it's worth remembering when writing her: the composed host
+in the parlor is the same person who once looked at five people boiling to death and said one
+word.
+
+**Everyone who is not the party calls her "The Lady."** Neverember and Quentin Voss use nothing
+else in ch. 53, capitalized, and Neverember's account of her is the outside view of the character:
+*"She is not one to be denied, even by — perhaps especially by — the likes of me,"* and *"she never
+leaves a loose end; she will return for you in her own time."*
 
 **She is self-aware about her own verbosity** — "make my best attempt to be laconic" — and then
 delivers four hundred words on Vecna anyway.
@@ -296,6 +323,46 @@ Alustriel up by the end of it.
 **She is amused by Gven rather than threatened by her**, which is the correct read and is worth
 keeping consistent.
 
+## Dagult Neverember
+
+**Male human · Lord of Neverwinter · scenes in ch. 53, 62, 63; referenced in ch. 56 and 57**
+
+**Two names, and the chapters use both.** He is **Dagult Neverember** in ch. 53, 56, and 57, and
+**"Lord Neverwinter"** — the title, not the surname — in ch. 53, 62, and 63. Ch. 53 is the only
+place both appear, and it reconciles them: *"butler to the Lord of Neverwinter, Dagult
+Neverember."* The appendix uses Neverember. **Use Neverember in narration; "Lord Neverwinter" reads
+as how people address him.**
+
+- **Look** high-born and visibly worn down. Lengthy arms he spreads when apologizing. "His eyes are
+  weary, almost cloudy, as though lack of sleep is finally catching up to him."
+- **Household** **Quentin Voss**, his butler — portly, short, does the escorting and the tending.
+  A library extensive enough to lose an archaeologist in. Brass lanterns, polished dark oak, oil
+  paintings.
+- **Family** his mother is **Indrina Lamsensettle**, found dead in an open casket in ch. 62.
+
+**Voice rule — the courteous ask that is not a request.** Every speech of his does the same three
+things in the same order: a warm framing, an apology for the imposition, then the favour. He never
+states the obligation out loud, because The Lady already did that for him.
+
+> "Friends, for I hope that we can become such in time, you have been given to my care by The
+> Lady." *(ch. 53, opening)*
+
+> "He spreads his lengthy arms in a way of apology. 'Food will be served shortly, but I must
+> request your indulgence a bit longer.'" *(ch. 53)*
+
+> "Would you be willing to investigate these criminal acts for us, in the name of the city's law,
+> while you await The Lady's return?" *(ch. 53 — the ask, and note what it's tied to)*
+
+**He flatters accurately, which is how it works on them**: *"particular skills, an unusual level of
+competence, and a proven willingness to help others."* All three are true, and the last one is the
+campaign's standing weakness.
+
+**He disparages his own city's institutions freely** — "the ineptitude of our constablery confounds
+them" — and this is the only heat he ever shows.
+
+**He pays generously and after the fact.** The Neverdeath job leads to five deeded houses on a
+cul-de-sac in the Bluelake District in ch. 63. The party never negotiated for any of it.
+
 ---
 
 ## Appendix gaps for these four
@@ -352,8 +419,15 @@ value first, by how likely they are to come back:
   vision. Live thread, will return.
 - **Mercy, Justice, Charity, Pious, 404, and Filch** — the warforged pilgrims of Ialos. Owed a debt.
 - **Hanseath** — Bilwin's god; ch. 29, 31, 32, 75. The rules-breaking drunk.
-- **Gustaf Mondalbrot** — ch. 42–52, the mapmaker. Whereabouts currently unaddressed.
+- **Gustaf Mondalbrot** — ch. 42–53, the mapmaker. **Last seen alive** in Neverember's library in
+  ch. 53, "entombed there, devouring texts long since given to dust," and not mentioned since.
 - **Veylara** — the storm giant. **Tempest Edge is still hers**; this reunion is owed.
 - **Torp / Davanor** — alive, hunting his sister across planes.
-- **Eva Brightbroom**, **Gertrude**, **Ikasa**, **Redbud**, **Captain Inda**, **Tham**,
+- **Tham (Thamnoki Grumblebuster)** — ch. 52–53. **Promoted from comic relief to traitor** by ch. 53
+  and then removed from the board entirely. If he returns he needs a register for the betrayal, not
+  just the drink; the one line he has is *"Och, nay...nay! Had I kent, I wid ne'er hae—"* and it
+  holds the Scots even in horror.
+- **Quentin Voss** — Neverember's butler, ch. 53. Portly, short, correct. Two speeches, both
+  logistics. Only needs an entry if he speaks again.
+- **Eva Brightbroom**, **Gertrude**, **Ikasa**, **Redbud**, **Captain Inda**,
   **Cap'n Don Karnahge**, **Cindel Trueshot**, **Umberto Noblin**, **Sarcelle Malinosh**.

--- a/.claude/story-so-far.md
+++ b/.claude/story-so-far.md
@@ -4,12 +4,14 @@ Storylines and character arcs, for use when drafting or revising. The appendix
 (`_posts/2023-01-23-appendix.md`) is the reference index — who, what, where. This is the shape of
 the story: what each arc was about, what changed for each character, and what was left open.
 
-**Coverage: chapters 1–85**, the complete campaign, read in full and cross-checked against the
-appendix.
+**Coverage: chapters 1–85**, the complete campaign as published, read in full and cross-checked
+against the appendix.
 
-Note that **chapters 53–55 do not exist as posts** — they were sessions that never got written up.
-The appendix records their content (the arrival in Neverwinter, the Gilded Glyph, Hallix Mausoleum,
-meeting Alustriel Silverhand), and ch. 56 opens as if the reader had been there.
+Note that **chapters 54 and 55 do not exist as posts** — sessions that never got written up. **Ch. 53
+was written on 22–23 August 2026**, a year and a half after its session, and files under its session
+date of 14 April 2025. It closes the Temple of Aish and puts the party in Neverwinter. The appendix
+records what happened in the two still missing (the Gilded Glyph, the Fucking Duck, Hallix
+Mausoleum), and ch. 56 opens as if the reader had been there.
 
 ---
 
@@ -148,7 +150,7 @@ Her advice: "don't trust your senses overly much."
 The arc ends mid-approach, still short of the temple, fighting an undead tyrannosaurus that vomits
 zombies.
 
-## Arc IV — The Temple of Aish (ch. 40–52)
+## Arc IV — The Temple of Aish (ch. 40–53)
 
 The dungeon crawl the campaign is still, in a sense, inside. The party crosses Amonah to the volcano
 temple, and the antagonist finally acquires a name — or rather refuses to: **The One**.
@@ -188,17 +190,55 @@ by a giant crab, inside a bubble holding back a cavern of boiling water. Along t
 Gustaf carries Blackrazor because he's the only one it can't seduce, and rigs a scabbard for it out
 of Dave Chevits's knitted scarves.
 
-## The gap (ch. 53–55)
+**Ch. 53 is where it all goes wrong**, and it goes wrong immediately. Dolor has the trident and the
+prophecy is solved — and then all three weapons reject their bearers at once. Blackrazor has to be
+clawed off Gustaf's back. Whelm shakes itself out of a dwarf's grip. Wave frosts over and burns
+Dolor's hand with cold. The three of them hit the floor together, glow, and set up a resonance felt
+in the bone rather than heard, and the space above the cavern tears open. **Something waits inside
+the rift and watches, patiently.**
 
-Three unwritten sessions. Per the appendix: the party leaves Amonah — Gven's later summary in ch. 63
-says they were *"suddenly transported to Neverwinter"* — arrives on a different plane, shops at the
-**Gilded Glyph** and the **Fucking Duck**, first encounters **Alustriel Silverhand**, and finds
-**Hallix Mausoleum**. Ch. 56 opens as they leave the Gilded Glyph.
+Then **Tham** — the drunk they picked up in a pantry one chapter earlier — stumbles forward with
+his eyes wide in horror and gives the campaign its first real betrayal:
+
+> "Och, nay...nay! Had I kent, I wid ne'er hae—"
+
+He grabs Wave off the floor and hurls it into the rift. The trident tears the opening wide and the
+boiling sea comes through. The party is scalded, slammed, drowned, and dying, and there is no
+version of the fight they win.
+
+**Alustriel Silverhand stops time.** She walks through the frozen flood untouched — silver hair, a
+cloak that shimmers like a starlit sky, the unicorn-headed staff — says *"Enough,"* and delivers the
+verdict the arc has been building to: *"You have played into his hand. But there are still more
+cards to be dealt."* **This is her first appearance in the campaign, and she is never named in it** —
+she is "The Lady" to Neverember and Voss and nothing at all to the party. The name *Alustriel
+Silverhand* first reaches the page in ch. 63; Mordenkainen introduces her out loud in ch. 64.
+
+They wake in clean beds in **Neverwinter**, wounds tended, clothes washed and folded. **Quentin
+Voss**, butler to **Lord Dagult Neverember**, walks them to a sitting room where Neverember —
+high-born, exhausted, careful — explains that they have been left in his care by "The Lady," who is
+not one to be denied, and who never leaves a loose end. Then he asks for the favour: people are
+being kidnapped in his city, his constables are useless, and there are whisperings about the
+graveyard. **The party pretends to deliberate.** They have no idea where they are, how they got
+there, or how to get home, and they always say yes to this.
+
+Two people don't come back with them. **Gustaf** is fine — already in Neverember's library, "entombed
+there, devouring texts long since given to dust." **Tham is simply gone.** Neverember has never heard
+of him and The Lady never mentioned him.
+
+Ch. 52 was quietly revised alongside ch. 53 to seed the betrayal: Tham now hesitates before agreeing
+to join them — *"Confusion or self-preservation causes him to lower his head for a moment"* — and
+his sudden competence in the crab fight is flagged as **"Suddenly seeming sober."**
+
+## The gap (ch. 54–55)
+
+Two unwritten sessions, between the Neverwinter arrival and the graveyard. Per the appendix: the
+party shops at the **Gilded Glyph** and the **Fucking Duck**, and finds **Hallix Mausoleum**. Ch. 56
+opens as they leave the Gilded Glyph.
 
 ## Arc V — Neverdeath and Evernight (ch. 56–63)
 
-Lord Neverember hires them to find people who went into Neverdeath Graveyard and didn't come out. It
-looks like a job. It's the hinge of the campaign.
+They take up the job Neverember gave them in ch. 53 — find the people who went into Neverdeath
+Graveyard and didn't come out. It looks like a job. It's the hinge of the campaign.
 
 They recover **Sarcelle Malinosh**, a sorceress stripped of her magic, who saw a skeletal figure on a
 hilltop in a vision that still frightens her: *"It was Vecna."* Then **Umberto Noblin**, a gnome
@@ -466,8 +506,17 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
   the whole rod.
 - **Tempest Edge is borrowed.** Gven owes Veylara the blade's return; the storm giant wears her
   father's medallion as an earring.
-- **Getting home.** The party has been on other planes since roughly ch. 53 and Mond, at least, is
-  no longer certain he wants to go back.
+- **Getting home.** The party has been on other planes since ch. 53, when Alustriel deposited them
+  in Neverwinter without explanation, and Mond, at least, is no longer certain he wants to go back.
+- **Tham betrayed them and vanished.** He threw Wave into the rift in ch. 53 knowing something the
+  party still doesn't — *"Had I kent, I wid ne'er hae—"* — and has not appeared since. Neverember
+  had never heard of him. Whether he was The One's from the start, coerced, or simply frightened is
+  unanswered, and nobody in the party has yet said his name out loud again.
+- **Wave, Whelm, and Blackrazor.** Wave went into the rift. Whelm and Blackrazor hit the cavern floor
+  in ch. 53 and **no chapter since has mentioned any of the three.** Bilwin lost a talking warhammer
+  that had been in his head for two chapters and has never remarked on it. Ch. 85's note calling the
+  Grimoire "the campaign's fourth talking magic item, after Whelm, Wave and Blackrazor" is the only
+  acknowledgement they ever existed.
 
 **Owed, promised, or simply left:**
 
@@ -480,8 +529,11 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
 - **Eva Brightbroom** is keeping five houses and a garden in Neverwinter and does not explain
   anything.
 - **The One** on Amonah — the entity that is neither god nor mortal, that carved its symbol over
-  B'raq's shrine and tore a piece off Zimon. The party took its three weapons and left the island
-  without ever meeting it. Nothing has closed this.
+  B'raq's shrine and tore a piece off Zimon. The party assembled its three weapons and never
+  delivered them; the prophecy's *"Death or glory? It's up to you"* was answered by a rift, a
+  betrayal, and a rescue. Alustriel's ch. 53 verdict — *"You have played into his hand"* — is the
+  only reading anyone has offered of what actually happened in that cavern, and **"his" has never
+  been identified.** Nothing has closed this.
 - **Lyra's favor.** A symbol drawn in dirt outside Wayside — mark it anywhere and a ranger comes.
   Never used, three years and several planes ago.
 - **The Heart of the People**, and Tella's contact **Brooj** at Elsemar's Hall of Records.

--- a/.claude/to-do-list.md
+++ b/.claude/to-do-list.md
@@ -45,17 +45,21 @@ CLAUDE.md says to preserve HTML comments.
 
 ---
 
-## 2. Chapters 53, 54, 55 were never written
+## 2. Chapters 54 and 55 were never written
 
-Not a numbering skip — three sessions that never got written up. The appendix documents their
-content and links to them, so **seven appendix links are 404s on the live site**, and ch. 56 opens
-with "The adventurers leave The Gilded Glyph," a shop the reader has never seen.
+Not a numbering skip — sessions that never got written up. ~~Ch. 53~~ **written 22–23 Aug 2026** and
+published under its session date, 14 April 2025. It covers the end of White Plume Mountain, Tham's
+betrayal, Alustriel's rescue, and Lord Neverember's commission — so the arrival in Neverwinter and
+first contact with Alustriel are both now on the page.
 
-What happened in them, per the appendix: the arrival in Neverwinter, the Gilded Glyph (magic shop,
-Maelis Varn), the Fucking Duck (dwarven jeweler), Hallix Mausoleum, and first contact with
-Alustriel Silverhand.
+Still missing, per the appendix: the Gilded Glyph (magic shop, Maelis Varn), the Fucking Duck
+(dwarven jeweler), and Hallix Mausoleum. Ch. 56 still opens with "The adventurers leave The Gilded
+Glyph," a shop the reader has never seen.
 
-- [ ] Decide: write them, or renumber, or leave them as a gap and fix the links to point elsewhere
+The appendix's dead links, recounted after ch. 53 shipped: **7 links to `chapter-53/` now
+resolve**, and **7 are still 404** — 5 to `chapter-54/` and 2 to `chapter-55/`.
+
+- [ ] Decide for 54 and 55: write them, or leave them as a gap and fix the links to point elsewhere
 
 **Ch. 55 was the party's first-ever magic shopping trip** and its consequences are already loose in
 the prose. Full item list is in `characters.md` under "Gear bought off-page." Four items were bought

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -504,7 +504,7 @@ campaign. This is the hardest thing to imitate and the most important to get rig
 | Nyx (tabaxi) | Laconic, dry. "I got hungry." Feline tells slipped in — a purr, a lope |
 | The sphinx | Bored and deadpan; answers only what it was built to answer |
 | Dave Chevits | Fences with knitting needles; opens by disambiguating themself from David Shevitz. **This is a disguise** — see below |
-| Tham (Thamnoki Grumblebuster) | Heavy phonetic Scots, every line. "Ach, aye. This is whit I wis lookin' for! Cannae leave wi'oot some scran, noo can I." |
+| Tham (Thamnoki Grumblebuster) | Heavy phonetic Scots, every line — held even in horror when he betrays them in ch. 53. "Ach, aye. This is whit I wis lookin' for! Cannae leave wi'oot some scran, noo can I." |
 | Cap'n Don Karnahge | Phonetic Scots plus delight in his own machinery. "It wirks! It really wirks!" Two rules on his ship, and rule one is "dinnae faw aff" |
 | Cindel | Self-mythologizing. "Huzzah!", a billowing cape, and a shaft of sunlight that finds her *and only her* on an overcast day |
 | Xantic | Gnome artificer, ch. 1–14. Curiosity with no brakes and no sense of consequence |
@@ -519,7 +519,7 @@ campaign. This is the hardest thing to imitate and the most important to get rig
 Give every new NPC one rule like this and hold it for every line they speak.
 
 **Phonetic Scots is your most-reused dialect, and it is getting crowded.** The tortle at the Hall
-of Records (ch. 16), Cap'n Don Karnahge (ch. 22–34), and Tham (ch. 52) are all written the same
+of Records (ch. 16), Cap'n Don Karnahge (ch. 22–34), and Tham (ch. 52–53) are all written the same
 way, and Captain Inda's pirate is adjacent. Two of them carry working notes in the file — ch. 16
 links a Scots translator, ch. 34 keeps a plain-English version of Don's speech in a comment — so
 this is a deliberate tool, not an accident. It is effective and it is a lot of work to read. Before


### PR DESCRIPTION
Ch. 53 closes the Temple of Aish arc and lands the party in Neverwinter. That moves several things the `.claude/` docs had recorded as unknown, unwritten, or belonging to a later chapter. Reference docs only — no posts touched.

### `story-so-far.md`
- **Arc IV extends to ch. 53.** Adds the three weapons rejecting their bearers at once, the rift and the thing watching inside it, Tham's betrayal, Alustriel stopping time, the Neverwinter arrival, and Neverember's commission. Also records that ch. 52 was revised alongside ch. 53 to seed the betrayal.
- **"The gap" is now ch. 54–55.** Ch. 53 exists, was written 22–23 Aug 2026, and files under its session date of 14 April 2025.
- **Arc V no longer opens with Neverember hiring them** — that happens in ch. 53; ch. 56 is them taking up the job.
- **Three new open threads:** Tham betrayed them and vanished; Wave, Whelm and Blackrazor are unaccounted for and unmentioned since; The One's prophecy went unanswered and Alustriel's "his" has never been identified.

### `npc-characters.md`
- **Alustriel's first appearance moves from "ch. 55 (unwritten)" to ch. 53** — the starlit cloak, her four lines, "She speaks without urgency, only truth," and the fact that she is never named in the chapter.
- **"The Lady"** documented as what everyone outside the party calls her.
- **New entry: Dagult Neverember**, with a voice rule and the `Neverember` / `Lord Neverwinter` split the chapters actually use (surname in 53/56/57, title-as-name in 53/62/63, reconciled by Voss's introduction in 53).
- **Tham and Quentin Voss** added to "still to build out"; **Gustaf's whereabouts** resolved — Neverember's library.

### `characters.md`
- **Bilwin gains "Whelm, and losing it."** He carried a talking warhammer for three chapters, lost it in ch. 53, and no chapter since mentions it.
- Gear callout warns against arming anyone with the White Plume weapons after ch. 52.

### `to-do-list.md`
- Item 2 is now **chapters 54 and 55**. Dead appendix links recounted: **7 links to `chapter-53/` now resolve, 7 remain** — 5 to `chapter-54/`, 2 to `chapter-55/`.

### `writing-voice.md`
- Tham's two citations updated to ch. 52–53, noting he holds the Scots even in horror.

---

Every claim is quoted or cited from the chapters. One correction made during review: an earlier draft said the party doesn't learn Alustriel's name for eleven chapters — the name actually first reaches the page in ch. 63, so that now reads as "never named in ch. 53."

🤖 Generated with [Claude Code](https://claude.com/claude-code)