### PR TITLE
Close out the three White Plume weapons

### DIFF
--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -22,8 +22,8 @@ class, height or age, so it sits outside the table with its own section.
 >
 > **The three White Plume weapons are gone.** Whelm, Wave, and Blackrazor were carried for two
 > chapters and lost in ch. 53 — see "Whelm, and losing it" under Bilwin. Do not arm anyone with them
-> after ch. 52. **Whelm and Blackrazor are closed for good**; Wave went into the rift and is still
-> an open question.
+> after ch. 52. **All three are closed for good** — none of them returns and nobody goes back for
+> them.
 
 ---
 
@@ -74,12 +74,14 @@ itself out of his grip — the prose makes a point of dwarven hand strength fail
 floor alongside Wave and Blackrazor. **Neither Bilwin nor anyone else has mentioned it since** — no
 chapter from 56 on refers to the hammer at all, and nothing in the prose marks the loss.
 
-**That is the ending, and it is deliberate** (author's decision, 23 Aug 2026). Whelm and Blackrazor
-are finished as story objects. Bilwin does not get the hammer back, does not go looking for it, and
-does not deliver a scene about having lost it. If his weapon comes up after ch. 53, it is the
-hurdy-gurdy. (Dolor held **Wave** for a matter of minutes in the same scene, long enough for it to
-frost over and cold-burn his hand open; Tham then threw it into the rift — **Wave is a separate
-question and still open**, because it went somewhere rather than nowhere.)
+**That is the ending, and it is deliberate** (author's decision, 23 Aug 2026). Whelm is finished as
+a story object. Bilwin does not get the hammer back, does not go looking for it, and does not
+deliver a scene about having lost it. If his weapon comes up after ch. 53, it is the hurdy-gurdy.
+
+The same holds for the other two. Dolor held **Wave** for a matter of minutes in the same scene,
+long enough for it to frost over and cold-burn his hand open, before Tham threw it through the rift;
+**Blackrazor** was clawed off Gustaf's back and left on the floor. **All three are closed** — none
+of them returns, and nobody goes back for them.
 
 ## Dolor Vagarpie
 

--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -22,7 +22,8 @@ class, height or age, so it sits outside the table with its own section.
 >
 > **The three White Plume weapons are gone.** Whelm, Wave, and Blackrazor were carried for two
 > chapters and lost in ch. 53 — see "Whelm, and losing it" under Bilwin. Do not arm anyone with them
-> after ch. 52.
+> after ch. 52. **Whelm and Blackrazor are closed for good**; Wave went into the rift and is still
+> an open question.
 
 ---
 
@@ -71,9 +72,14 @@ Whelm clutched tightly in his hand and his head tipped a little to the side, as 
 to something," which is the last good moment either of them gets. Minutes later the hammer vibrates
 itself out of his grip — the prose makes a point of dwarven hand strength failing — and hits the
 floor alongside Wave and Blackrazor. **Neither Bilwin nor anyone else has mentioned it since** — no
-chapter from 56 on refers to the hammer at all, and nothing in the prose marks the loss. (Dolor
-held **Wave** for a matter of minutes in the same scene, long enough for it to frost over and
-cold-burn his hand open; Tham then threw it into the rift.)
+chapter from 56 on refers to the hammer at all, and nothing in the prose marks the loss.
+
+**That is the ending, and it is deliberate** (author's decision, 23 Aug 2026). Whelm and Blackrazor
+are finished as story objects. Bilwin does not get the hammer back, does not go looking for it, and
+does not deliver a scene about having lost it. If his weapon comes up after ch. 53, it is the
+hurdy-gurdy. (Dolor held **Wave** for a matter of minutes in the same scene, long enough for it to
+frost over and cold-burn his hand open; Tham then threw it into the rift — **Wave is a separate
+question and still open**, because it went somewhere rather than nowhere.)
 
 ## Dolor Vagarpie
 

--- a/.claude/story-so-far.md
+++ b/.claude/story-so-far.md
@@ -512,21 +512,20 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
   party still doesn't — *"Had I kent, I wid ne'er hae—"* — and has not appeared since. Neverember
   had never heard of him. Whether he was The One's from the start, coerced, or simply frightened is
   unanswered, and nobody in the party has yet said his name out loud again.
-- **Wave went into the rift.** Tham threw it, the rift tore wide, and nothing since has said where
-  the trident ended up. This is a question about The One and about what was watching from inside
-  the opening — not about the party's gear.
-
 **Owed, promised, or simply left:**
 
 - ~~**The pilot's helmet** from Landro, promised to the warforged pilgrims of Ialos.~~ **Closed in
   ch. 85** — they left it with the pilgrims on the way out of Mournland, and Charity accepted it. It
   is inert now that the pilot's chamber is destroyed. The gemstone promised alongside it in ch. 82
   stays with the party as Landro's vessel.
-- ~~**Whelm and Blackrazor.**~~ **Closed by authorial decision, 23 Aug 2026.** Both hit the cavern
-  floor in ch. 53 and stay there. **Their stories are ended.** Do not write a recovery, a callback,
-  or a scene in which anyone remembers them — the silence from ch. 56 on is the intended ending, not
-  an oversight to repair. Ch. 85's note calling the Grimoire "the campaign's fourth talking magic
-  item, after Whelm, Wave and Blackrazor" is the last word either of them gets.
+- ~~**Wave, Whelm, and Blackrazor.**~~ **All three closed by authorial decision, 23 Aug 2026.**
+  Whelm and Blackrazor hit the cavern floor in ch. 53 and stay there; Wave went through the rift and
+  does not come back. **Their stories are ended.** Do not write a recovery, a callback, or a scene
+  in which anyone remembers them — the silence from ch. 56 on is the intended ending, not an
+  oversight to repair. Ch. 85's note calling the Grimoire "the campaign's fourth talking magic item,
+  after Whelm, Wave and Blackrazor" is the last word any of them gets. **The rift is a separate
+  matter**: what tore it open, and what was watching from inside it, still belong to The One's
+  thread below.
 - **Mercy and Filch**, returned to Ialos. **Gertrude**, last seen swinging a greatclub into fifteen
   cultists. **Ikasa** wants to find Palenna; the appendix says Palenna was rescued.
 - **Eva Brightbroom** is keeping five houses and a garden in Neverwinter and does not explain

--- a/.claude/story-so-far.md
+++ b/.claude/story-so-far.md
@@ -512,11 +512,9 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
   party still doesn't — *"Had I kent, I wid ne'er hae—"* — and has not appeared since. Neverember
   had never heard of him. Whether he was The One's from the start, coerced, or simply frightened is
   unanswered, and nobody in the party has yet said his name out loud again.
-- **Wave, Whelm, and Blackrazor.** Wave went into the rift. Whelm and Blackrazor hit the cavern floor
-  in ch. 53 and **no chapter since has mentioned any of the three.** Bilwin lost a talking warhammer
-  that had been in his head for two chapters and has never remarked on it. Ch. 85's note calling the
-  Grimoire "the campaign's fourth talking magic item, after Whelm, Wave and Blackrazor" is the only
-  acknowledgement they ever existed.
+- **Wave went into the rift.** Tham threw it, the rift tore wide, and nothing since has said where
+  the trident ended up. This is a question about The One and about what was watching from inside
+  the opening — not about the party's gear.
 
 **Owed, promised, or simply left:**
 
@@ -524,6 +522,11 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
   ch. 85** — they left it with the pilgrims on the way out of Mournland, and Charity accepted it. It
   is inert now that the pilot's chamber is destroyed. The gemstone promised alongside it in ch. 82
   stays with the party as Landro's vessel.
+- ~~**Whelm and Blackrazor.**~~ **Closed by authorial decision, 23 Aug 2026.** Both hit the cavern
+  floor in ch. 53 and stay there. **Their stories are ended.** Do not write a recovery, a callback,
+  or a scene in which anyone remembers them — the silence from ch. 56 on is the intended ending, not
+  an oversight to repair. Ch. 85's note calling the Grimoire "the campaign's fourth talking magic
+  item, after Whelm, Wave and Blackrazor" is the last word either of them gets.
 - **Mercy and Filch**, returned to Ialos. **Gertrude**, last seen swinging a greatclub into fifteen
   cultists. **Ikasa** wants to find Palenna; the appendix says Palenna was rescued.
 - **Eva Brightbroom** is keeping five houses and a garden in Neverwinter and does not explain


### PR DESCRIPTION
Wave, Whelm, and Blackrazor all leave the story in ch. 53 and no chapter since mentions any of them. Recording that as the intended ending rather than a gap, so a future draft doesn't try to repair it.

### `story-so-far.md`
- **All three move out of "Live and load-bearing"** into the closed list as one entry, struck through and formatted like the pilot's helmet — the existing convention for a resolved thread. Whelm and Blackrazor stay on the cavern floor; Wave goes through the rift and does not come back.
- **The rift is explicitly carved out.** What tore it open and what was watching from inside it still belong to The One's thread, which remains open. Closing the trident does not close the hole it made.

### `characters.md`
- Bilwin's "Whelm, and losing it" now says the ending is deliberate: he doesn't get the hammer back, doesn't go looking for it, and doesn't get a scene about having lost it. If his weapon comes up after ch. 53, it's the hurdy-gurdy.
- Wave and Blackrazor recorded alongside it — none of the three returns, and nobody goes back for them.
- The gear callout at the top of the file says the same in one line, since that's what a drafting pass actually reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)