### PR TITLE
Fix graveyard mis-naming in ch. 62, and two modified dates

### DIFF
--- a/_posts/2025-03-17-chapter-52.md
+++ b/_posts/2025-03-17-chapter-52.md
@@ -3,7 +3,7 @@ title: "Chapter 52"
 show_date: true
 date: 2025-03-17T17:00:00-00:00
 sessiondate: "March 17, 2025"
-modified: 2025-03-17
+modified: 2026-08-22
 categories:
   - campaign
 tags:

--- a/_posts/2025-09-01-chapter-62.md
+++ b/_posts/2025-09-01-chapter-62.md
@@ -3,7 +3,7 @@ title: "Chapter 62"
 show_date: true
 date: 2025-09-01T17:00:00-00:00
 sessiondate: "September 1, 2025"
-modified: 2025-09-01
+modified: 2026-08-23
 categories:
   - campaign
 tags:
@@ -158,7 +158,7 @@ Seeing that everyone has left him he climbs into the coffin, "At least Gustaf wi
 
 ---
 
-Once everyone is through the crevice and safely in the Neverwinter Graveyard, Elden tells them how he was
+Once everyone is through the crevice and safely in the Neverdeath Graveyard, Elden tells them how he was
 abducted by the cultists.
 
 "Honestly, they didn't say anything or make demands, they just grabbed me from


### PR DESCRIPTION
Two small corrections, both companions to the ch. 53 work.

### The graveyard name — `_posts/2025-09-01-chapter-62.md:161`

The companion fix to `0ba4286`. Ch. 62 called it "Neverwinter Graveyard"; it's **Neverdeath Graveyard** everywhere else.

> Once everyone is through the crevice and safely in the ~~Neverwinter~~ **Neverdeath** Graveyard, Elden tells them how he was abducted by the cultists.

Canonical per the appendix Places entry ("**Neverdeath Graveyard** - Graveyard in Neverwinter"), the Hallix Mausoleum entry, and the four NPC entries that cite it — plus every other chapter from 56 on, including ch. 56's "the ironically named Neverdeath Graveyard," which is the joke the name exists for.

With this and the ch. 53 fix, **"Neverwinter Graveyard" appears nowhere in the repo.**

### Two `modified` dates

CLAUDE.md: "`modified` is set when a post is revised after publishing." Chapters 73, 78, and 84 were all bumped when revised on 2026-08-19; these two were missed.

| Post | Was | Now | Revised |
|---|---|---|---|
| ch. 62 | 2025-09-01 | 2026-08-23 | this PR |
| ch. 52 | 2025-03-17 | 2026-08-22 | `81cdab0`, alongside ch. 53 — Tham's hesitation and the "suddenly seeming sober" line |

Ch. 52's date comes from the commit that last touched it, not today, so the front matter reflects when the prose actually changed. Worth noting it was also edited on 2025-11-21 (`4056949`, `dad90fe`) without a bump — that one is unrecoverable now without rewriting history, and the 2026 date is the more useful of the two anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)