### PR TITLE
Sync reference docs to ch. 54, and rename Elden → Eldon

### DIFF
--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -74,6 +74,11 @@ itself out of his grip — the prose makes a point of dwarven hand strength fail
 floor alongside Wave and Blackrazor. **Neither Bilwin nor anyone else has mentioned it since** — no
 chapter from 56 on refers to the hammer at all, and nothing in the prose marks the loss.
 
+**Ch. 54 confirms the demeanor line above in one clause.** He starts to speak to The Lady — "his
+typical first response in every situation" — and she stops him with a look before a word gets out.
+The chapter treats it as unremarkable, which is the correct handling: Bilwin talking first is the
+default state, not a joke to be set up.
+
 **That is the ending, and it is deliberate** (author's decision, 23 Aug 2026). Whelm is finished as
 a story object. Bilwin does not get the hammer back, does not go looking for it, and does not
 deliver a scene about having lost it. If his weapon comes up after ch. 53, it is the hurdy-gurdy.
@@ -82,6 +87,13 @@ The same holds for the other two. Dolor held **Wave** for a matter of minutes in
 long enough for it to frost over and cold-burn his hand open, before Tham threw it through the rift;
 **Blackrazor** was clawed off Gustaf's back and left on the floor. **All three are closed** — none
 of them returns, and nobody goes back for them.
+
+**One qualification, added with ch. 54 (24 Aug 2026).** The Lady tells the party that someone *now
+bears* all three weapons and is using them to siphon magic from Eritz. That does not reopen Bilwin's
+side of it — he still never mentions Whelm again, never looks for it, and his weapon after ch. 53 is
+the hurdy-gurdy — but it does mean the hammer is not lying on a cavern floor somewhere being
+irrelevant. If Bilwin ever learns who holds it, that is a scene the closure did not anticipate.
+See `story-so-far.md` under "Owed, promised, or simply left" for the flag on this.
 
 ## Dolor Vagarpie
 

--- a/.claude/npc-characters.md
+++ b/.claude/npc-characters.md
@@ -82,7 +82,7 @@ The imperative register, in full:
 **She addresses people by role, warmly**: "my dear dwarf," "master dwarf," "young sorcerer," "sir
 dwarf." Her farewell is a formula: *"Farewell and may courage be your constant companion."*
 
-**Her first appearance is ch. 53, and it is the only time the party sees her act.** The temple
+**Her first appearance is ch. 53, and it is the only time the party sees her use power.** The temple
 cavern is flooding with boiling water and all five of them are drowning in it when she stops time —
 the surge freezes mid-crash, drops hang in the air "like crystal teardrops," the heat vanishes — and
 walks through it untouched. Her whole scene is five short lines, and the register is the imperative
@@ -102,6 +102,37 @@ the party wakes up in Neverwinter without having been told anything. **This is t
 later warmth is measured against**, and it's worth remembering when writing her: the composed host
 in the parlor is the same person who once looked at five people boiling to death and said one
 word.
+
+**Ch. 54 is her second appearance, and it is the counterweight to ch. 53.** She arrives as a flicker
+of fae light in a corner of the party's room — Dolor spots it and identifies the origin before she
+resolves — and this time she explains herself. The register is new: still time-pressured (*"I have
+little time, so we will forgo introductions"*, *"Time is short"*), but volunteering rather than
+withholding, and opening with something close to an apology: *"I feel like I owe you a better
+explanation of how and why you came to be here, along with some guidance."*
+
+**She silences Bilwin without a word**, which is the single most useful piece of business she has and
+the cheapest to reuse: he starts to speak, "his typical first response in every situation," and *"The
+Lady gives him a soft look, one that would calm a raging minotaur, and the dwarf's mouth remains
+slightly open even though no words come out."* No spell is named. Nobody remarks on it afterwards.
+
+**She has a third register beyond the composed host and the clipped imperative: the honest
+consoler.** Gven asks what any of this has to do with her brother, and Alustriel neither reassures
+her nor spares her — Torp's "inner demons weaken his resolve," he found ridicule where Gven found
+strength, and *"His fate is not yet completely written, but his path is a difficult one. Perhaps as
+difficult as yours."* Note the construction: she gives Gven a real answer, declines the comforting
+version, and ends by putting the two siblings on the same footing. When she needs to deliver bad
+news about someone the listener loves, this is how she does it.
+
+**She looks at people as an assessment.** Before vanishing she spends "a final moment looking into
+each of their eyes. It's more than just a glance, it's a measurement of their resolve, their courage,
+their ability to endure." Pairs with ch. 53's *"We shall soon see what you're made of."*
+
+**Her ch. 54 exposition is the campaign's central briefing** — the weapons as a beacon, the planar
+barrier weakening, an unnamed bearer siphoning magic from Eritz, and the link to the anti-arcane
+animosity back home. She frames the limits of her own knowledge honestly: *"That is most of what we
+know. The rest will come in time, as it always does. We hope that it comes in time to stop him."*
+Her sign-off, *"I will return for you as soon as I am able,"* matches Neverember's outside account of
+her almost word for word.
 
 **Everyone who is not the party calls her "The Lady."** Neverember and Quentin Voss use nothing
 else in ch. 53, capitalized, and Neverember's account of her is the outside view of the character:
@@ -325,10 +356,10 @@ keeping consistent.
 
 ## Dagult Neverember
 
-**Male human · Lord of Neverwinter · scenes in ch. 53, 62, 63; referenced in ch. 56 and 57**
+**Male human · Lord of Neverwinter · scenes in ch. 53, 54, 62, 63; referenced in ch. 56 and 57**
 
 **Two names, and the chapters use both.** He is **Dagult Neverember** in ch. 53, 56, and 57, and
-**"Lord Neverwinter"** — the title, not the surname — in ch. 53, 62, and 63. Ch. 53 is the only
+**"Lord Neverwinter"** — the title, not the surname — in ch. 53, 54, 62, and 63. Ch. 53 is the only
 place both appear, and it reconciles them: *"butler to the Lord of Neverwinter, Dagult
 Neverember."* The appendix uses Neverember. **Use Neverember in narration; "Lord Neverwinter" reads
 as how people address him.**
@@ -359,6 +390,14 @@ campaign's standing weakness.
 
 **He disparages his own city's institutions freely** — "the ineptitude of our constablery confounds
 them" — and this is the only heat he ever shows.
+
+**Ch. 54 is the briefing scene, and it shows him doing the work rather than asking for it.** Over
+breakfast he names the four missing citizens, and he has already spent his own money on divinations
+from the **House of Knowledge** — the priests traced the trail to **Hallix Mausoleum** and were
+blocked from seeing inside it. So the "ineptitude of our constablery" line from ch. 53 is not a man
+excusing himself: he exhausted the tools he had before he asked. Worth remembering when writing him,
+because it is the only evidence in the corpus that his helplessness is genuine rather than
+convenient.
 
 **He pays generously and after the fact.** The Neverdeath job leads to five deeded houses on a
 cul-de-sac in the Bluelake District in ch. 63. The party never negotiated for any of it.

--- a/.claude/story-so-far.md
+++ b/.claude/story-so-far.md
@@ -5,13 +5,14 @@ Storylines and character arcs, for use when drafting or revising. The appendix
 the story: what each arc was about, what changed for each character, and what was left open.
 
 **Coverage: chapters 1–85**, the complete campaign as published, read in full and cross-checked
-against the appendix.
+against the appendix. **Ch. 54 added 24 August 2026.**
 
-Note that **chapters 54 and 55 do not exist as posts** — sessions that never got written up. **Ch. 53
-was written on 22–23 August 2026**, a year and a half after its session, and files under its session
-date of 14 April 2025. It closes the Temple of Aish and puts the party in Neverwinter. The appendix
-records what happened in the two still missing (the Gilded Glyph, the Fucking Duck, Hallix
-Mausoleum), and ch. 56 opens as if the reader had been there.
+Note that **chapter 55 does not exist as a post** — a session that never got written up. **Ch. 53 was
+written on 22–23 August 2026 and ch. 54 on 24 August 2026**, both a year and a half after their
+sessions, filed under their session dates of 14 and 28 April 2025. Ch. 53 closes the Temple of Aish
+and puts the party in Neverwinter; ch. 54 is Neverember's briefing and The Lady's explanation. The
+appendix records what happened in the one still missing (the Gilded Glyph, the Fucking Duck), and
+ch. 56 opens as if the reader had been there.
 
 ---
 
@@ -229,11 +230,50 @@ Ch. 52 was quietly revised alongside ch. 53 to seed the betrayal: Tham now hesit
 to join them — *"Confusion or self-preservation causes him to lower his head for a moment"* — and
 his sudden competence in the crab fight is flagged as **"Suddenly seeming sober."**
 
-## The gap (ch. 54–55)
+## Ch. 54 — the briefing and The Lady's explanation
 
-Two unwritten sessions, between the Neverwinter arrival and the graveyard. Per the appendix: the
-party shops at the **Gilded Glyph** and the **Fucking Duck**, and finds **Hallix Mausoleum**. Ch. 56
-opens as they leave the Gilded Glyph.
+The morning after the Neverwinter arrival, and the chapter that finally says out loud what the
+campaign is about. Two scenes, no fight, ~670 words — the shortest chapter in the modern run.
+
+**Breakfast with Neverember.** He elaborates on the favour asked in ch. 53. The kidnappings run back
+months, all at night, with no visible connection between victims. Four are named here for the first
+time: **Eldon Keyward**, elven scholar of the Outer Planes; **Indrina Lamsensettle**, human actor in
+the highest social circles; **Sarcelle Malinosh**, human wild-magic sorcerer of the Outer Planes; and
+**Umberto Noblin**, gnome historian of deities. Three of the four are Outer Planes or divine
+specialists, which is the shape of the thing well before anyone says "Vecna." Neverember has funded
+divinations from the **House of Knowledge**; the priests followed the trail as far as **Hallix
+Mausoleum** in Neverdeath Graveyard and could not see inside it, blocked "by some unknown means—or
+individual."
+
+**The Lady's second appearance**, an hour later in the party's room. Dolor catches a flicker of light
+in a corner and knows it for fae before it resolves into her. She gives them the exposition the
+campaign has been withholding since ch. 53:
+
+- Bringing **Whelm, Wave, and Blackrazor** together in the Temple of Aish "set off a beacon to
+  dangerous foes" — brave, courageous, and clever, but rash.
+- Their combined magic **weakens the barrier between planes** and **grants the holder certain
+  powers**.
+- **Someone now bears those weapons**, and he is "of great concern" to her and her colleagues. His
+  motivation is unknown to them.
+- He is **siphoning magical energy from Eritz**, and that "appears to be connected to the animosity
+  towards arcane users on your home world" — the first line tying the Hands of the Wand and the
+  policing of magic in Elsemar to a cause outside Elsemar.
+
+Asked directly by Gven about Torp, she answers without softening it: the enemy "takes on many
+disguises, deceiving those who yearn for meaning beyond their normal experiences," and those who
+feel lost or slighted are easy prey to him. Torp's "inner demons weaken his resolve"; where Gven
+found strength in her mixed heritage, he found ridicule and humiliation. *"His fate is not yet
+completely written, but his path is a difficult one. Perhaps as difficult as yours."* It is the
+closest anyone has come to explaining Torp rather than reporting him.
+
+She asks them to assist Neverember, promises to return "as soon as I am able," and looks each of
+them in the eye — "more than just a glance, it's a measurement of their resolve, their courage,
+their ability to endure" — before vanishing. Mond: *"That was cryptic as fuck."*
+
+## The gap (ch. 55)
+
+One unwritten session, between the briefing and the graveyard. Per the appendix: the party shops at
+the **Gilded Glyph** and the **Fucking Duck**. Ch. 56 opens as they leave the Gilded Glyph.
 
 ## Arc V — Neverdeath and Evernight (ch. 56–63)
 
@@ -502,6 +542,11 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
   something more since ch. 66.
 - **Torp / Davanor** is alive, still pursuing genocide in Eritz, and tracking his sister across
   planes. Their last exchange was a letter on a corpse.
+- **The bearer of Whelm, Wave, and Blackrazor** — unnamed, and unmotivated as far as The Lady knows.
+  He is **siphoning magical energy from Eritz** (ch. 54), and she ties that to the animosity toward
+  arcane users on the party's home world, which retroactively gives the Hands of the Wand a cause
+  outside Elsemar. **Introduced ch. 54 and never followed up in ch. 56–85** — the party has never been
+  told who he is and has never gone looking. See the weapons note below before writing to this.
 - **Vecna**, the link he forced on the party in ch. 59, and the Chime of Exile plan that requires
   the whole rod.
 - **Tempest Edge is borrowed.** Gven owes Veylara the blade's return; the storm giant wears her
@@ -526,6 +571,15 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
   after Whelm, Wave and Blackrazor" is the last word any of them gets. **The rift is a separate
   matter**: what tore it open, and what was watching from inside it, still belong to The One's
   thread below.
+  **Amended by ch. 54, merged 24 Aug 2026 — the day after the closure decision.** The Lady names all
+  three on the page and says **someone now bears them**, that their combined magic weakens the planar
+  barrier and empowers whoever holds them, and that he is siphoning magic from Eritz. The closure
+  still holds where it was aimed: the **party's** relationship with the weapons is over, Bilwin does
+  not get Whelm back, and nobody goes looking. But the objects are no longer inert — they are the
+  antagonist's power source and the engine of the central mystery. Ch. 54 sits before ch. 56, so it
+  does not break "silence from ch. 56 on." **Decision needed from Tod:** if the closure was meant to
+  retire the weapons entirely rather than just the party's arc, ch. 54 is the line to change, because
+  as written it makes them load-bearing again.
 - **Mercy and Filch**, returned to Ialos. **Gertrude**, last seen swinging a greatclub into fifteen
   cultists. **Ikasa** wants to find Palenna; the appendix says Palenna was rescued.
 - **Eva Brightbroom** is keeping five houses and a garden in Neverwinter and does not explain
@@ -547,7 +601,7 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
 
 Worth knowing before drafting: the campaign keeps making the same move, and it works every time.
 **Someone the party has no reason to help asks for help, and they do it, and it costs them.** Preva's
-husband, Vera, the town of Wayside, Rightside, Sarcelle, Umberto, Elden, Figaro's crew, Redbud and
+husband, Vera, the town of Wayside, Rightside, Sarcelle, Umberto, Eldon, Figaro's crew, Redbud and
 Ikasa, Captain Inda's wing, Mercy's lost friend, and finally a blind golem that only wanted its maps
 back. Alustriel names it in ch. 67 as the reason they might survive Vecna at all. Gven complains
 about it in the bath in ch. 67 and does it again eight chapters later.

--- a/.claude/to-do-list.md
+++ b/.claude/to-do-list.md
@@ -1,6 +1,6 @@
 # To-do list
 
-Tracked suggestions from reading the full corpus (ch. 1–83) and the appendix. Nothing here has been
+Tracked suggestions from reading the full corpus (ch. 1–85, including ch. 54) and the appendix. Nothing here has been
 acted on — these are proposals for Tod to accept, reject, or reorder. Check items off in place.
 
 Grouped by size, biggest commitment first.
@@ -45,21 +45,21 @@ CLAUDE.md says to preserve HTML comments.
 
 ---
 
-## 2. Chapters 54 and 55 were never written
+## 2. Chapter 55 was never written
 
-Not a numbering skip — sessions that never got written up. ~~Ch. 53~~ **written 22–23 Aug 2026** and
-published under its session date, 14 April 2025. It covers the end of White Plume Mountain, Tham's
-betrayal, Alustriel's rescue, and Lord Neverember's commission — so the arrival in Neverwinter and
-first contact with Alustriel are both now on the page.
+Not a numbering skip — a session that never got written up. ~~Ch. 53~~ **written 22–23 Aug 2026** and
+~~ch. 54~~ **written 24 Aug 2026**, both published under their session dates (14 and 28 April 2025).
+Ch. 53 covers the end of White Plume Mountain, Tham's betrayal, Alustriel's rescue, and Neverember's
+commission. Ch. 54 covers the breakfast briefing — the four victims named, the House of Knowledge
+divinations, Hallix Mausoleum — and The Lady's second appearance, which is the campaign's central
+exposition. Hallix is therefore **no longer missing**; it is introduced in ch. 54.
 
-Still missing, per the appendix: the Gilded Glyph (magic shop, Maelis Varn), the Fucking Duck
-(dwarven jeweler), and Hallix Mausoleum. Ch. 56 still opens with "The adventurers leave The Gilded
-Glyph," a shop the reader has never seen.
+Still missing, per the appendix: the Gilded Glyph (magic shop, Maelis Varn) and the Fucking Duck
+(dwarven jeweler). Ch. 56 still opens with "The adventurers leave The Gilded Glyph," a shop the
+reader has never seen. Tod repointed the two shop entries from ch. 54 to ch. 55 in the same pass that
+merged ch. 54, so the appendix is internally consistent.
 
-The appendix's dead links, recounted after ch. 53 shipped: **7 links to `chapter-53/` now
-resolve**, and **7 are still 404** — 5 to `chapter-54/` and 2 to `chapter-55/`.
-
-- [ ] Decide for 54 and 55: write them, or leave them as a gap and fix the links to point elsewhere
+- [ ] Decide for 55: write it, or leave it as a gap and fix the links to point elsewhere
 
 **Ch. 55 was the party's first-ever magic shopping trip** and its consequences are already loose in
 the prose. Full item list is in `characters.md` under "Gear bought off-page." Four items were bought
@@ -106,10 +106,21 @@ if a future chapter trusted them.
 
 ### Typos and inconsistencies
 
+- [x] ~~**Keyward: two spellings.**~~ **Resolved 24 Aug 2026 — Tod's call: Eldon, with an o.**
+      Renamed across the corpus: ch. 59, 60, 61, 62, 62-ai, 63, and the appendix. Ch. 54 already had
+      it right. `story-so-far.md` and `writing-voice.md` updated too. **Eldon Keyward is now the only
+      spelling in the repo.**
+- [ ] **Ch. 54 HTML comment**: "siutation" for "situation", in the cut Bilwin battle-hammer aside.
+      Cosmetic — it does not render — but it is in the working notes if that aside is ever restored.
+- [ ] **Ch. 54 has no `co-written-with-claude` tag.** If it was drafted with Claude it needs one per
+      `CLAUDE.md`; if Tod wrote it unaided, no action. Its tags are `eve-of-ruin` and `neverwinter`
+      only — note it also carries no `secret-learned` tag despite being the chapter where the party
+      learns what the weapons did.
+
 - [ ] "Cyndal" for Cindel, in the Low Elves membership list
 - [ ] "Inda Malayui" (Characters) vs "Inda Malayuri" (Ships) — same person
 - [ ] "The Guilded Glyph" → "Gilded" (in the Fucking Duck entry)
-- [ ] Elden Keyward described as "Male elven scholar" then "enlists the group to find **her**"
+- [ ] Eldon Keyward described as "Male elven scholar" then "enlists the group to find **her**"
       (copy-paste from the Sarcelle / Indrina / Umberto entries, which share the sentence)
 - [ ] "praticioners" → practitioners (Eyes of the Star entry)
 - [ ] "proprieter" → proprietor (Boscoe); "penchance" → penchant (Dave Chevits)

--- a/.claude/writing-voice.md
+++ b/.claude/writing-voice.md
@@ -621,7 +621,7 @@ happens, not a break from it.
 ## Profanity
 
 Used sparingly and always as a punchline or a pressure release, never as texture. "Well, fuck."
-ends chapter 63. Elden shrugs "Fuck you all" and jumps into a portal. Kycera's "Get that fucker!"
+ends chapter 63. Eldon shrugs "Fuck you all" and jumps into a portal. Kycera's "Get that fucker!"
 launches a fight. Grindlefoot's "Do you want to fuck yarn or do you want this?" is the biggest
 laugh in the run. Keep it rare enough that it lands.
 

--- a/_posts/2023-01-23-appendix.md
+++ b/_posts/2023-01-23-appendix.md
@@ -3,7 +3,7 @@ title: "Appendix"
 show_date: true
 date: 2023-01-23T12:30:00-00:00
 sessiondate: "June 6, 2023"
-modified: 2025-08-04
+modified: 2026-08-24
 categories:
   - notes
 tags:
@@ -92,7 +92,7 @@ a [map of Eritz and the neighboring seas](/dnd/assets/images/eritz-northern-hemi
     Iron Vulture, a mid-sized ship docked in Elsemar. [[ch. 22](/dnd/campaign/chapter-22/)]
 *   **Elar** - Human husband of Preva who was captured by goblins, along with their
     daughter, Vera, while out hunting in the forests surrounding Wayside.
-*   **Elden Keyward** - Male elven scholar of the outer planes. He's kidnapped and
+*   **Eldon Keyward** - Male elven scholar of the outer planes. He's kidnapped and
     Lord Neverember enlists the group to find her in Neverdeath Graveyard.
     [[ch. 54](/dnd/campaign/chapter-54/), [ch. 59](/dnd/campaign/chapter-59/)]
 *   **Elve** - Male human member of the Low Elves in Wayside. [[ch. 2](/dnd/campaign/chapter-2/)]

--- a/_posts/2025-07-21-chapter-59.md
+++ b/_posts/2025-07-21-chapter-59.md
@@ -3,7 +3,7 @@ title: "Chapter 59"
 show_date: true
 date: 2025-07-21T17:00:00-00:00
 sessiondate: "July 21, 2025"
-modified: 2025-07-21
+modified: 2026-08-24
 categories:
   - campaign
 tags:
@@ -247,7 +247,7 @@ enveleloping the remaining attackers, swiftly turning two of them into ashes.
   Grindlefoot - 0
   Gven - 0
   Mond - 0
-  Elden - 5 & paralyzed
+  Eldon - 5 & paralyzed
 -->
 
 <!-- Round 2 -->
@@ -275,10 +275,10 @@ from its shoulder to its hip, cutting it in half.
 
 Several minutes later, Bilwin and the elf regain their ability to move and introductions ensue.
 
-"I'm Elden Keyward, and you have my utmost gratitude for rescuing me. Please ignore my comments
+"I'm Eldon Keyward, and you have my utmost gratitude for rescuing me. Please ignore my comments
 about wanting to go back. I was, um, in shock, I think."
 
-Both Elden and Bilwin whisper a few [words](https://www.dndbeyond.com/spells/2619143-healing-word) and their
+Both Eldon and Bilwin whisper a few [words](https://www.dndbeyond.com/spells/2619143-healing-word) and their
 wounds magically smooth over, the skin healing underneath the sticky blood. 
 
 Eventually, the group climbs the sides of the pit to see where they are and get their bearings. Perhaps
@@ -291,7 +291,7 @@ even as they move on their own. Looking closely at the trees, they notice the ja
 connect to each other, the distinct lack of leaves, and their dull gray coloring. Looking up to the sky,
 the stars look as though they're swimming in oil, not the usual clear or cloudy night sky.
 
-Elden sighs, "This isn't good, but it's not surprising. We're in Evernight. It's a mirror plane of Neverwinter,
+Eldon sighs, "This isn't good, but it's not surprising. We're in Evernight. It's a mirror plane of Neverwinter,
 populated only by the undead. We need to find a crevice of dusk to get back to our plane. Let's head towards the
 market, we might get lucky there."
 

--- a/_posts/2025-08-04-chapter-60.md
+++ b/_posts/2025-08-04-chapter-60.md
@@ -3,7 +3,7 @@ title: "Chapter 60"
 show_date: true
 date: 2025-08-04T17:00:00-00:00
 sessiondate: "August 04, 2025"
-modified: 2025-08-04
+modified: 2026-08-24
 categories:
   - campaign
 tags:
@@ -15,7 +15,7 @@ tags:
 ---
 
 As the companions make their way through the Evernight version of Neverdeath Graveyard,
-Elden Keyward, a renouned scholar of the outer planes, explains the concept of a crevice of dusk. 
+Eldon Keyward, a renouned scholar of the outer planes, explains the concept of a crevice of dusk. 
 
 "It's essentially a weak spot between two specific planes of existence, the mortal world where the Neverwinter
 we know exists and this gloomy world, called Shadowfell. Everwinter is basically a twisted, demented mirror image
@@ -55,30 +55,30 @@ but they have no idea what time of day it might be. They hear ghouls and other c
 yet none bother them or come into sight. The eerieness plays on their nerves, making each of them a bit jumpier
 than usual.
 
-"They call this the City of Eternal Night, because the sun never rises here. Look, there's the market." Elden
+"They call this the City of Eternal Night, because the sun never rises here. Look, there's the market." Eldon
 stops and points down the road they're traveling, where the others can see a bustling market with plenty of
 tented shops and all manner of undead and otherworldly creatures walking alone and in pairs.
 
 With her [eagle eyesight](https://dnd5e.wikidot.com/barbarian:totem-warrior#toc2),
 Gven can see a few humans mixed amongst the moderate-sized crowd. "We should walk in pairs, I don't see any
-groups larger than that." Seeing Elden pull his hood up and close, then smear some dirt on his face and cloak, she continues,
-"If our luck holds, we can disguise ourselves enough to blend in and find what we need. Elden and I'll go first,
+groups larger than that." Seeing Eldon pull his hood up and close, then smear some dirt on his face and cloak, she continues,
+"If our luck holds, we can disguise ourselves enough to blend in and find what we need. Eldon and I'll go first,
 you follow in pairs close enough to keep us in sight."
 
-Thirty seconds after Gven and Elden enter the market area, Mond and Bilwin follow. The pair attempts to peruse
+Thirty seconds after Gven and Eldon enter the market area, Mond and Bilwin follow. The pair attempts to peruse
 the vendors' wares, but discover that the merchandise is disgusting or beyond their comprehension. They can't tell
 what much of it might be. Dolor and Grindlefoot follow the half-elf and dwarf, giving them enough lead time to
 appear unconnected. Of all of them, the tiefling appears to blend in the most with the crowd because of his infernal
 bloodline's physical stature, horns on his head, four foot long tail, and pointed canine teeth. His calm demeanor
 brings some amount of truth to the facade, as well as instills confidence in his halfling companion.
 
-Meandering through the market, quickly looking over merchandise and the sellers, neither Gven nor Elden see
+Meandering through the market, quickly looking over merchandise and the sellers, neither Gven nor Eldon see
 anything or anyone that might be helpful in their search. Passing by a booth with shelves of vials and jars
 containing different shades of red liquid, the shopkeeper points at them.
 
 "You don't belong here, do you?" It's a statement, not a question.
 
-Gven looks to Elden, who silently shrinks behind the larger half-orc, then answers the shopkeeper. "Is it that obvious?"
+Gven looks to Eldon, who silently shrinks behind the larger half-orc, then answers the shopkeeper. "Is it that obvious?"
 
 "Yes, my dear, it's quite obvious. At least, to those who pay attention." 
 
@@ -178,7 +178,7 @@ Another of the spawn attacks Grindlefoot, but the halfling is able to jump away 
 Unexpectedly, one of the attackers is able to grapple Mond, holding the sorcerer in its undeadly grasp and
 preventing him from moving.
 
-Elden looks at the vampire spawn who has seized Mond, speaks a few words, and a
+Eldon looks at the vampire spawn who has seized Mond, speaks a few words, and a
 [flame-like radiance](https://www.dndbeyond.com/spells/2236-sacred-flame) descends upon the creature. It
 writhes in pain, but maintains its hold on the half-elf.
 
@@ -229,7 +229,7 @@ through their legs at the knees, dropping their torso to the ground in death.
 
 Grindlefoot jumps towards the mausoleum, eager to be away from their deadly foes. He opens the wooden door,
 sees a steep staircase spiraling down, and takes the first few steps. Gven is close behind him, not wanting
-her smaller companion to face anything alone. Dolor, Elden, Mond, and Bilwin follow them into the crypt,
+her smaller companion to face anything alone. Dolor, Eldon, Mond, and Bilwin follow them into the crypt,
 crowding into the upper area.
 
 Before anyone can touch the door's handle, it closes.

--- a/_posts/2025-08-18-chapter-61.md
+++ b/_posts/2025-08-18-chapter-61.md
@@ -3,7 +3,7 @@ title: "Chapter 61"
 show_date: true
 date: 2025-08-18T17:00:00-00:00
 sessiondate: "August 18, 2025"
-modified: 2025-08-18
+modified: 2026-08-24
 categories:
   - campaign
 tags:
@@ -52,7 +52,7 @@ Turning to the pedestal next to the helmet, Bilwin scoops the pile of gold coins
 slight movement of his hand, measures their weight. "About twenty two hundred in gold coins. That'll be useful,
 don't ya say, Dolor!"
 
-Curious about the large tomb, Gven walks to the pedestal to read the title, "Out of the Endless Prison." Elden
+Curious about the large tomb, Gven walks to the pedestal to read the title, "Out of the Endless Prison." Eldon
 responds, "I know that one. It's refering to Carceri, an outer plane also known as the Red Prison where demons
 and devils war endlessly. Nasty place. Right up your alley."
 
@@ -63,22 +63,22 @@ Knowing that elves consider humans beneath them, Gven's insult hits its mark.
 
 Pulling Tempest Edge from its sheath, Gven barks at the elf, "Come closer and tell me more."
 
-Elden brings his hands together in the beginnings of a spell, "With pleasure."
+Eldon brings his hands together in the beginnings of a spell, "With pleasure."
 
 Dolor sees the trouble brewing and, as quietly as he can, gruffly yells at the half-orc and elf, "Stop it, both of
 you! This is no time or place to continue an ethnic feud neither of you started."
 
-In a huff of anger, Elden stomps off towards the stairs that ascend back to the higher level. Reaching a closed door
+In a huff of anger, Eldon stomps off towards the stairs that ascend back to the higher level. Reaching a closed door
 at the top, he kicks open the door without regard for what might be on the other side and passes through.
 
 "I want to explore too"! Bilwin follows the elf up the stairs and through the hastly opened door.
-Glancing at Gven, still fuming from her encounter with Elden, Dolor realizes she needs a moment—or two or three—to
+Glancing at Gven, still fuming from her encounter with Eldon, Dolor realizes she needs a moment—or two or three—to
 calm down and goes after the dwarf and elf. Mond and Grindlefoot follow behind, leaving Gven to her anger,
 pacing around the pedestals.
 
 ---
 
-Dolor finds Elden at the top of the stairs, mumbling about stupid, gray-skinned, tusk-mouthed orcs. Looking around,
+Dolor finds Eldon at the top of the stairs, mumbling about stupid, gray-skinned, tusk-mouthed orcs. Looking around,
 the tiefling sees that they're in a small antechamber with two doors, one directly in front of them, across from
 the stairs, and another to their right. The door to their right, on the eastern wall, is ornately carved wood with
 tiles inset into two lines, one above the other. The top line reads "DOLINDAR" and the bottom spells out "NO WORLD
@@ -126,7 +126,7 @@ Just then, another creature erupts from the closed coffin, growling with eagerne
 Dolor yells as loud as possible, "Gven!"
 
 An arm extends from the second creature with amazing speed, its claw piercing Bilwin's armor and digging into his
-shoulder. The dwarf screams in pain as Grindlefoot steps into the room, with Mond and Elden immediately behind.
+shoulder. The dwarf screams in pain as Grindlefoot steps into the room, with Mond and Eldon immediately behind.
 
 Seeing the two monsters engaged with Dolor and Bilwin, Grindlefoot realizes that caution is warranted. He casts
 [Stoneskin](https://www.dndbeyond.com/spells/2619095-stoneskin) on himself, improving his resistance to melee damage.
@@ -141,7 +141,7 @@ Unfortunately, the creature in front of him makes no move to leave, rather it gr
 Mond quickly lashes out with a psychic spell, [Tasha's Mind Whip](https://dnd5e.wikidot.com/spell:tashas-mind-whip),
 causing both creatures to wail momentarily at the pain inside their minds.
 
-Elden, the professorial elf, quickly looks around the room and understands their peril. "Shit.
+Eldon, the professorial elf, quickly looks around the room and understands their peril. "Shit.
 [Sorrowsworn](https://thecampaign20xx.blogspot.com/2020/03/dungeons-dragons-guide-to-sorrowsworn.html)." From his raised hand,
 a [bright streak of light](https://www.dndbeyond.com/spells/2619136-guiding-bolt) shoots towards the monster holding
 Dolor, hitting it square in the chest—and avoiding the tiefling. It shrieks in pain at the injury, obviously hurt.
@@ -194,7 +194,7 @@ swings Tempest Edge from her hip, striking upwards, the force removing the creat
 to her side, she sees the dwarf lying motionless on the ground. The rage inside her grows as she launches
 herself at the remaining monster, who evades her deadly attack with a step backwards.
 
-Elden runs over to the fallen dwarf, "It's not your time yet, dwarf." He
+Eldon runs over to the fallen dwarf, "It's not your time yet, dwarf." He
 [lays his hand](https://www.dndbeyond.com/spells/2619079-cure-wounds) on Bilwin and closes his eyes for a brief
 moment, calling forth his druidic healing energy.
 
@@ -242,7 +242,7 @@ With the sorrowsworn vanquished, Mond moves to investigate the two coffins. He f
 One reads "Nolan Dolander - Beloved Brother" and the other states "Evisha Dolander - Beloved Sister."
 
 "This plane of Shadowfell must have used their exceptional loneliness and strong siblings bond to somehow turn them
-into [lonely sorrowsworn](https://5e.tools/bestiary/lonely-sorrowsworn-mpmm.html), as you identified, Elden. An interesting
+into [lonely sorrowsworn](https://5e.tools/bestiary/lonely-sorrowsworn-mpmm.html), as you identified, Eldon. An interesting
 development."
 
 While the others are preoccupied with their surroundings and helping Bilwin out of his predicament, Dolor
@@ -265,7 +265,7 @@ Several seconds later, the tiles pop out and they're all flush again.
 spelling out "WORD TO TURN."
 
 Immediately, everyone in the group feels a deep sadness that envelopes their soul. The emotional pain is strong enough
-to push Elden, Dolor, and Gven to kneel on the ground. A large keyhole appears centered beneath the word puzzle.
+to push Eldon, Dolor, and Gven to kneel on the ground. A large keyhole appears centered beneath the word puzzle.
 
 A minute later, Dolor regains his focus, comes to his feet, and investigates the magically revealed lock. Retrieving
 his lockpick from a pocket, the tiefling inserts the pick and moves it around in various directions, attempting to

--- a/_posts/2025-09-01-chapter-62-ai.md
+++ b/_posts/2025-09-01-chapter-62-ai.md
@@ -3,7 +3,7 @@ title: "Chapter 62 - AI Version"
 show_date: true
 date: 2025-09-01T19:00:00-00:00
 sessiondate: "September 1, 2025"
-modified: 2025-09-01
+modified: 2026-08-24
 categories:
   - campaign
 tags:
@@ -154,26 +154,26 @@ The challenge was now how to get everyone across the dangerous floor to the sarc
 using **spider form** to "bring them over". However, Gven had another idea: **"My plan was just to have givan and
 I pick up the lid and continuously throw it and break off the plates and wake up every time"**. Gven was determined:
 **"Yeah, do the smash. I'll say the spider"**. Gven (with rage advantage on Athletics checks) proceeded to
-**"decimat[e] the floor of this this room"** with the sarcophagus lid for about 30 minutes, creating a path. Elden,
+**"decimat[e] the floor of this this room"** with the sarcophagus lid for about 30 minutes, creating a path. Eldon,
 the NPC they rescued, observed, remembering a past argument and commenting, **"I don't like her when she's angry"**.
 
-Elden then confirmed the liquid was a "stable crevice". The group decided to leave, with Elden stating, **"You know
+Eldon then confirmed the liquid was a "stable crevice". The group decided to leave, with Eldon stating, **"You know
 what? Fuck you and Pops in and monthly vanishes"**. Dolor followed. Bilwin then suggested marking the exit to alert
 guards. Bilwin used Prestidigitation to **"soil the door"** of the building they emerged from, specifically spelling
 out "Bad" or an inverse of "wash me" to make a permanent mark.
 
-### Emergence and Encounter with Elden & Lord Neverwinter:
+### Emergence and Encounter with Eldon & Lord Neverwinter:
 
 The party emerged from the crevice into a "run down" area. Gven, with a perception check of "three," was surprised
-when Elden, who had gone ahead, suddenly appeared from behind a bed with **"surprise!"**. Gven instinctively swung,
-but Elden was able to duck. 
+when Eldon, who had gone ahead, suddenly appeared from behind a bed with **"surprise!"**. Gven instinctively swung,
+but Eldon was able to duck. 
 
 They discussed the crevice, confirming it was a one-way passage, unlike the unstable one they had initially fallen
-through. Elden offered insight into the "Dablendars" (presumably the former inhabitants of the crypt), suggesting
+through. Eldon offered insight into the "Dablendars" (presumably the former inhabitants of the crypt), suggesting
 they were "cursed really" and that their "strong emotional. Energy" might have stabilized the crevice. He also
 lamented that "the way out. Only came only became available after she died".
 
-The group questioned Elden further about his capture. Elden, a scholar of "outer planes," recounted being **"kidnapped
+The group questioned Eldon further about his capture. Eldon, a scholar of "outer planes," recounted being **"kidnapped
 me. That's all I have to say they didn't say anything. Nothing about nothing to you. They just put through you in the
 the sphere. Started torturing. He's, like, yes, wow pretty much"**. He also shared a personal "secret" he overheard
 cultists discussing: **"So, there's this Inn now. His daughter's love for me? Wait, this, what? There's an N, and

--- a/_posts/2025-09-01-chapter-62.md
+++ b/_posts/2025-09-01-chapter-62.md
@@ -3,7 +3,7 @@ title: "Chapter 62"
 show_date: true
 date: 2025-09-01T17:00:00-00:00
 sessiondate: "September 1, 2025"
-modified: 2026-08-23
+modified: 2026-08-24
 categories:
   - campaign
 tags:
@@ -146,19 +146,19 @@ and swords shatter at the weight of the stone lid. Stepping into the recessed ar
 head and throws it down on another section of the deadly weapons, pulverizing them. She does this over and over
 until she's cleared a path from the door to the sarcophagus.
 
-With newfound respect for the half-orc, Elden quietly comments to Mond, "I don't like her when she's angry."
+With newfound respect for the half-orc, Eldon quietly comments to Mond, "I don't like her when she's angry."
 
-Reaching the coffin, Elden confirms that it's a stable crevice of dusk. Before anyone can pose a question,
+Reaching the coffin, Eldon confirms that it's a stable crevice of dusk. Before anyone can pose a question,
 the elf shrugs, "Fuck you all," and jumps in, vanishing. 
 
-As the rest follow Elden's lead, Mond holds out a piece of paper. "Look, I made a map of the Dolindar's tomb."
+As the rest follow Eldon's lead, Mond holds out a piece of paper. "Look, I made a map of the Dolindar's tomb."
 Seeing that everyone has left him he climbs into the coffin, "At least Gustaf will appreciate this."
 
 ![Dolindar tomb as drawn by Mond](/dnd/assets/images/ch60-drawn-map-Dolindar-tomb-800px.jpeg){: .align-center }
 
 ---
 
-Once everyone is through the crevice and safely in the Neverdeath Graveyard, Elden tells them how he was
+Once everyone is through the crevice and safely in the Neverdeath Graveyard, Eldon tells them how he was
 abducted by the cultists.
 
 "Honestly, they didn't say anything or make demands, they just grabbed me from
@@ -173,7 +173,7 @@ Reaching Lord Neverwinter's estate, the nobleman brings them into an elaborately
 open casket. Inside is a woman with brown hair and unremarkable features, wearing a flowing black dress
 and fitted bodice. Her eyes are closed, as though she's only resting.
 
-"I see that you rescued Elden. Thank you for that. Alas, Indrina was not so fortunate. We discovered her
+"I see that you rescued Eldon. Thank you for that. Alas, Indrina was not so fortunate. We discovered her
 body in a cell inside the cultist's tomb." Lowering his head in mourning, "My mother was beloved by all
 and will be missed."
 

--- a/_posts/2025-09-15-chapter-63.md
+++ b/_posts/2025-09-15-chapter-63.md
@@ -3,7 +3,7 @@ title: "Chapter 63"
 show_date: true
 date: 2025-09-15T17:00:00-00:00
 sessiondate: "September 15, 2025"
-modified: 2025-09-15
+modified: 2026-08-24
 categories:
   - campaign
 tags:
@@ -17,7 +17,7 @@ tags:
 casket, "We have other priorities. Besides, you're all fresh from battle and I'm sure you would like sustenance
 and rest. You can stay here if you wish, as my guests."
 
-The five adventurers nod their heads in agreement to the offer, while Elden expresses his desire to return
+The five adventurers nod their heads in agreement to the offer, while Eldon expresses his desire to return
 to his own home.
 
 "Of course, Professor Keyward, my driver shall escort you. For the rest of you, my staff will show you


### PR DESCRIPTION
Follow-on to ch. 54 merging. Two passes, 12 files, no chapter prose rewritten.

## 1. Reference docs caught up to ch. 54

`CLAUDE.md` says a chapter isn't finished until the `.claude/` files catch up, and ch. 54 moved a fair amount.

- **`story-so-far.md`** — "The gap (ch. 54–55)" becomes a full ch. 54 section plus a shortened "The gap (ch. 55)". Coverage note updated: ch. 55 is now the only unwritten session. Added the bearer of the three weapons to the open threads.
- **`npc-characters.md`** — Alustriel gains a substantial block. Ch. 54 is her second appearance and gives her a **third register** beyond the two already documented: the honest consoler, from her answer to Gven about Torp. Also the fae-light arrival, and the piece of business worth reusing — she silences Bilwin with a look, no spell named, nobody remarks on it. Neverember gains the breakfast briefing, which is the only evidence in the corpus that his helplessness is genuine: he'd already paid for divinations before he asked.
- **`characters.md`** — Bilwin's "speaks first" demeanor line gets its ch. 54 confirmation.
- **`to-do-list.md`** — item 2 narrows to ch. 55 only. Hallix Mausoleum is no longer listed as missing, since ch. 54 introduces it.

## 2. Eldon Keyward, with an o

43 occurrences renamed across **ch. 59, 60, 61, 62, 62-ai, 63 and the appendix**. Ch. 54 already had it right — the misspelling was everywhere *except* the newest chapter. `modified:` bumped on all seven posts per the front-matter convention.

## Two things that need a decision

**Ch. 54 qualifies the weapons closure.** The Whelm/Wave/Blackrazor closure was made 23 Aug; ch. 54 merged the next morning with The Lady saying *someone now bears those weapons* and is siphoning magic from Eritz with them. Chronologically it's fine — ch. 54 sits before ch. 56, and ch. 56 and 57 contain no weapon references (the two "wave" hits in 57 are the ordinary word). I recorded the closure as still governing the *party's* arc while flagging that the objects are no longer inert. If the closure was meant to retire them entirely, ch. 54 is the line to change.

**`chapter-62-ai.md` was included in the rename** (9 occurrences). That file is the preserved fully-AI alternate version, so editing it alters the artifact. I included it because the instruction was a blanket fix and because the file was already internally inconsistent — one "Eldon" alongside seven "Elden". Easy to drop from this PR if you'd rather it stay verbatim.

## Still open in `to-do-list.md`

Ch. 54 has no `co-written-with-claude` tag, and no `secret-learned` tag despite being the chapter where the party learns what the weapons did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)