### PR TITLE
Sync story-so-far to the ch. 54 edit

### DIFF
--- a/.claude/story-so-far.md
+++ b/.claude/story-so-far.md
@@ -266,6 +266,11 @@ found strength in her mixed heritage, he found ridicule and humiliation. *"His f
 completely written, but his path is a difficult one. Perhaps as difficult as yours."* It is the
 closest anyone has come to explaining Torp rather than reporting him.
 
+**She tells them where they are**, which nobody had until now: *"You should be safe here, in a
+different plane, at least for a while. It is similar to your home world, you shall acclimate
+quickly."* It is hedged on every axis — *should* be safe, *at least for a while* — and it is still
+the only orientation the party is ever given.
+
 She asks them to assist Neverember, promises to return "as soon as I am able," and looks each of
 them in the eye — "more than just a glance, it's a measurement of their resolve, their courage,
 their ability to endure" — before vanishing. Mond: *"That was cryptic as fuck."*
@@ -551,8 +556,10 @@ Battle of Wayside. Leaves to protect Wayside. Has his own character post.
   the whole rod.
 - **Tempest Edge is borrowed.** Gven owes Veylara the blade's return; the storm giant wears her
   father's medallion as an earring.
-- **Getting home.** The party has been on other planes since ch. 53, when Alustriel deposited them
-  in Neverwinter without explanation, and Mond, at least, is no longer certain he wants to go back.
+- **Getting home.** The party has been on other planes since ch. 53. The Lady told them in ch. 54
+  that they are on a different plane, "similar to your home world," and safe "at least for a while"
+  — but never how they get back, and she has not returned for them as promised. Mond, at least, is
+  no longer certain he wants to go back.
 - **Tham betrayed them and vanished.** He threw Wave into the rift in ch. 53 knowing something the
   party still doesn't — *"Had I kent, I wid ne'er hae—"* — and has not appeared since. Neverember
   had never heard of him. Whether he was The One's from the start, coerced, or simply frightened is


### PR DESCRIPTION
`0303cac` added two sentences to The Lady's speech in ch. 54 — she now tells the party where they are:

> "You should be safe here, in a different plane, at least for a while. It is similar to your home world, you shall acclimate quickly."

Two places in `story-so-far.md` needed that; the rest of the ch. 54 sync (`c1e397b`) already covers the chapter.

### The ch. 54 section
Records the line, and notes that it's hedged on every axis — *should* be safe, *at least for a while* — while still being the only orientation the party is ever given.

### The "Getting home" thread
It said the party had been on other planes since ch. 53, "when Alustriel deposited them in Neverwinter without explanation." That's no longer true. Now: she explains *where* in ch. 54, but never *how they get back*, and she has not returned for them as promised.

---

**Still open, and not resolved by this edit:** the amendment note under the closed weapons entry ends with *"Decision needed from Tod: if the closure was meant to retire the weapons entirely rather than just the party's arc, ch. 54 is the line to change, because as written it makes them load-bearing again."* Ch. 54 has The Lady naming all three weapons and saying someone now bears them, which sits against the 23 Aug closure. The docs currently split it — party's arc closed, objects live as the antagonist's power source — but that split is an inference, not your ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)